### PR TITLE
Shape refinement for U+1395

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1395.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1395.glif
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni1395" format="2">
-  <advance width="2023"/>
+  <advance width="1169"/>
   <unicode hex="1395"/>
   <outline>
     <contour>
-      <point x="1770" y="525" type="curve"/>
-      <point x="1770" y="426"/>
-      <point x="1752" y="325"/>
-      <point x="1688" y="267" type="curve" smooth="yes"/>
-      <point x="1648" y="230"/>
-      <point x="1485" y="161"/>
-      <point x="80" y="23" type="curve"/>
-      <point x="117" y="5"/>
-      <point x="171" y="5"/>
-      <point x="235" y="5" type="curve" smooth="yes"/>
-      <point x="360" y="5"/>
-      <point x="609" y="15"/>
-      <point x="796" y="31" type="curve" smooth="yes"/>
-      <point x="1040" y="52"/>
-      <point x="1285" y="74"/>
-      <point x="1527" y="101" type="curve" smooth="yes"/>
-      <point x="1573" y="106"/>
-      <point x="1707" y="124"/>
-      <point x="1747" y="141" type="curve" smooth="yes"/>
-      <point x="1910" y="211"/>
-      <point x="1937" y="367"/>
-      <point x="1939" y="530" type="curve"/>
-      <point x="1769" y="530" type="line"/>
-      <point x="1769" y="528"/>
-      <point x="1770" y="527"/>
+      <point x="1085" y="583" type="curve" smooth="yes"/>
+      <point x="1084" y="631"/>
+      <point x="1073" y="672"/>
+      <point x="1036" y="705" type="curve" smooth="yes"/>
+      <point x="1030" y="712"/>
+      <point x="1016" y="715"/>
+      <point x="1008" y="715" type="curve" smooth="yes"/>
+      <point x="844" y="715" type="line"/>
+      <point x="872" y="684"/>
+      <point x="890" y="654"/>
+      <point x="900" y="622" type="curve" smooth="yes"/>
+      <point x="910" y="587"/>
+      <point x="913" y="551"/>
+      <point x="909" y="507" type="curve" smooth="yes"/>
+      <point x="903" y="430"/>
+      <point x="874" y="379"/>
+      <point x="836" y="332" type="curve" smooth="yes"/>
+      <point x="736" y="209"/>
+      <point x="458" y="51"/>
+      <point x="80" y="12" type="curve"/>
+      <point x="83" y="2"/>
+      <point x="109" y="3"/>
+      <point x="115" y="3" type="curve" smooth="yes"/>
+      <point x="411" y="-7"/>
+      <point x="785" y="108"/>
+      <point x="929" y="218" type="curve" smooth="yes"/>
+      <point x="1029" y="294"/>
+      <point x="1089" y="405"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
This is an update for a single glyph, U+1395 which is more in keeping with the regular way that it is written.  The current Abyssinica version is a little elongated and too flat.  The refinement here will better match the reference glyph from the Unicode charts.