### PR TITLE
Subscript and Circled Digits

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/contents.plist
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/contents.plist
@@ -4,38 +4,56 @@
 <dict>
   <key>eight</key>
   <string>eight.glif</string>
+  <key>eight.inferior</key>
+  <string>eight.inferior.glif</string>
   <key>eightsuperior</key>
   <string>eightsuperior.glif</string>
   <key>five</key>
   <string>five.glif</string>
+  <key>five.inferior</key>
+  <string>five.inferior.glif</string>
   <key>fivesuperior</key>
   <string>fivesuperior.glif</string>
   <key>four</key>
   <string>four.glif</string>
+  <key>four.inferior</key>
+  <string>four.inferior.glif</string>
   <key>foursuperior</key>
   <string>foursuperior.glif</string>
   <key>nine</key>
   <string>nine.glif</string>
+  <key>nine.inferior</key>
+  <string>nine.inferior.glif</string>
   <key>ninesuperior</key>
   <string>ninesuperior.glif</string>
   <key>one</key>
   <string>one.glif</string>
+  <key>one.inferior</key>
+  <string>one.inferior.glif</string>
   <key>onesuperior</key>
   <string>onesuperior.glif</string>
   <key>seven</key>
   <string>seven.glif</string>
+  <key>seven.inferior</key>
+  <string>seven.inferior.glif</string>
   <key>sevensuperior</key>
   <string>sevensuperior.glif</string>
   <key>six</key>
   <string>six.glif</string>
+  <key>six.inferior</key>
+  <string>six.inferior.glif</string>
   <key>sixsuperior</key>
   <string>sixsuperior.glif</string>
   <key>three</key>
   <string>three.glif</string>
+  <key>three.inferior</key>
+  <string>three.inferior.glif</string>
   <key>threesuperior</key>
   <string>threesuperior.glif</string>
   <key>two</key>
   <string>two.glif</string>
+  <key>two.inferior</key>
+  <string>two.inferior.glif</string>
   <key>twosuperior</key>
   <string>twosuperior.glif</string>
   <key>u1E7E0</key>
@@ -192,6 +210,8 @@
   <string>uni137C_.nobar.glif</string>
   <key>zero</key>
   <string>zero.glif</string>
+  <key>zero.inferior</key>
+  <string>zero.inferior.glif</string>
   <key>zerosuperior</key>
   <string>zerosuperior.glif</string>
 </dict>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/eight.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/eight.inferior.glif
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="eight.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="727" y="850" type="curve" smooth="yes"/>
+      <point x="727" y="942"/>
+      <point x="662" y="1028"/>
+      <point x="520" y="1059" type="curve"/>
+      <point x="668" y="1087"/>
+      <point x="709" y="1169"/>
+      <point x="709" y="1251" type="curve" smooth="yes"/>
+      <point x="709" y="1366"/>
+      <point x="600" y="1460"/>
+      <point x="395" y="1460" type="curve" smooth="yes"/>
+      <point x="203" y="1460"/>
+      <point x="80" y="1366"/>
+      <point x="80" y="1251" type="curve" smooth="yes"/>
+      <point x="80" y="1157"/>
+      <point x="141" y="1083"/>
+      <point x="279" y="1059" type="curve"/>
+      <point x="131" y="1028"/>
+      <point x="63" y="942"/>
+      <point x="63" y="850" type="curve" smooth="yes"/>
+      <point x="63" y="715"/>
+      <point x="193" y="614"/>
+      <point x="397" y="614" type="curve" smooth="yes"/>
+      <point x="590" y="614"/>
+      <point x="727" y="715"/>
+    </contour>
+    <contour>
+      <point x="555" y="1239" type="curve" smooth="yes"/>
+      <point x="555" y="1157"/>
+      <point x="485" y="1106"/>
+      <point x="397" y="1106" type="curve" smooth="yes"/>
+      <point x="309" y="1106"/>
+      <point x="238" y="1157"/>
+      <point x="238" y="1239" type="curve" smooth="yes"/>
+      <point x="238" y="1323"/>
+      <point x="309" y="1372"/>
+      <point x="397" y="1372" type="curve" smooth="yes"/>
+      <point x="485" y="1372"/>
+      <point x="555" y="1329"/>
+    </contour>
+    <contour>
+      <point x="571" y="858" type="curve" smooth="yes"/>
+      <point x="571" y="758"/>
+      <point x="483" y="709"/>
+      <point x="395" y="709" type="curve" smooth="yes"/>
+      <point x="307" y="709"/>
+      <point x="219" y="756"/>
+      <point x="219" y="858" type="curve" smooth="yes"/>
+      <point x="219" y="954"/>
+      <point x="295" y="1006"/>
+      <point x="397" y="1006" type="curve" smooth="yes"/>
+      <point x="496" y="1006"/>
+      <point x="571" y="954"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/five.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/five.inferior.glif
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="five.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="695" y="895" type="curve" smooth="yes"/>
+      <point x="695" y="1028"/>
+      <point x="594" y="1157"/>
+      <point x="406" y="1157" type="curve" smooth="yes"/>
+      <point x="322" y="1157"/>
+      <point x="262" y="1139"/>
+      <point x="201" y="1083" type="curve"/>
+      <point x="211" y="1309" type="line"/>
+      <point x="629" y="1309" type="line"/>
+      <point x="629" y="1436" type="line"/>
+      <point x="97" y="1436" type="line"/>
+      <point x="78" y="950" type="line"/>
+      <point x="197" y="950" type="line"/>
+      <point x="213" y="1012"/>
+      <point x="256" y="1063"/>
+      <point x="363" y="1063" type="curve" smooth="yes"/>
+      <point x="482" y="1063"/>
+      <point x="529" y="997"/>
+      <point x="529" y="895" type="curve" smooth="yes"/>
+      <point x="529" y="793"/>
+      <point x="475" y="709"/>
+      <point x="355" y="709" type="curve" smooth="yes"/>
+      <point x="265" y="709"/>
+      <point x="213" y="768"/>
+      <point x="205" y="829" type="curve"/>
+      <point x="58" y="829" type="line"/>
+      <point x="58" y="768"/>
+      <point x="101" y="614"/>
+      <point x="346" y="614" type="curve" smooth="yes"/>
+      <point x="592" y="614"/>
+      <point x="695" y="760"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/four.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/four.inferior.glif
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="four.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="764" y="791" type="line"/>
+      <point x="764" y="909" type="line"/>
+      <point x="662" y="909" type="line"/>
+      <point x="662" y="1436" type="line"/>
+      <point x="446" y="1436" type="line"/>
+      <point x="55" y="948" type="line"/>
+      <point x="55" y="791" type="line"/>
+      <point x="508" y="791" type="line"/>
+      <point x="508" y="614" type="line"/>
+      <point x="662" y="614" type="line"/>
+      <point x="662" y="791" type="line"/>
+    </contour>
+    <contour>
+      <point x="508" y="909" type="line"/>
+      <point x="172" y="909" type="line"/>
+      <point x="508" y="1335" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/nine.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/nine.inferior.glif
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="nine.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="730" y="1055" type="curve" smooth="yes"/>
+      <point x="730" y="1378"/>
+      <point x="571" y="1460"/>
+      <point x="395" y="1460" type="curve" smooth="yes"/>
+      <point x="216" y="1460"/>
+      <point x="48" y="1372"/>
+      <point x="48" y="1174" type="curve" smooth="yes"/>
+      <point x="48" y="975"/>
+      <point x="216" y="909"/>
+      <point x="343" y="909" type="curve" smooth="yes"/>
+      <point x="454" y="909"/>
+      <point x="528" y="946"/>
+      <point x="569" y="987" type="curve"/>
+      <point x="540" y="748"/>
+      <point x="479" y="702"/>
+      <point x="370" y="702" type="curve" smooth="yes"/>
+      <point x="276" y="702"/>
+      <point x="249" y="764"/>
+      <point x="249" y="813" type="curve"/>
+      <point x="85" y="813" type="line"/>
+      <point x="85" y="702"/>
+      <point x="200" y="614"/>
+      <point x="370" y="614" type="curve" smooth="yes"/>
+      <point x="581" y="614"/>
+      <point x="730" y="731"/>
+    </contour>
+    <contour>
+      <point x="565" y="1182" type="curve" smooth="yes"/>
+      <point x="565" y="1079"/>
+      <point x="485" y="995"/>
+      <point x="388" y="995" type="curve" smooth="yes"/>
+      <point x="290" y="995"/>
+      <point x="212" y="1079"/>
+      <point x="212" y="1182" type="curve" smooth="yes"/>
+      <point x="212" y="1284"/>
+      <point x="290" y="1366"/>
+      <point x="388" y="1366" type="curve" smooth="yes"/>
+      <point x="485" y="1366"/>
+      <point x="565" y="1284"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/one.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/one.inferior.glif
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="one.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="536" y="614" type="line"/>
+      <point x="536" y="1436" type="line"/>
+      <point x="374" y="1436" type="line"/>
+      <point x="352" y="1407"/>
+      <point x="229" y="1323"/>
+      <point x="161" y="1300" type="curve"/>
+      <point x="161" y="1174" type="line"/>
+      <point x="221" y="1188"/>
+      <point x="327" y="1231"/>
+      <point x="380" y="1272" type="curve"/>
+      <point x="380" y="614" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/seven.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/seven.inferior.glif
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="seven.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="709" y="1309" type="line"/>
+      <point x="709" y="1436" type="line"/>
+      <point x="82" y="1436" type="line"/>
+      <point x="82" y="1309" type="line"/>
+      <point x="575" y="1309" type="line"/>
+      <point x="188" y="614" type="line"/>
+      <point x="395" y="614" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/six.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/six.inferior.glif
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="six.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="745" y="901" type="curve" smooth="yes"/>
+      <point x="745" y="1100"/>
+      <point x="575" y="1165"/>
+      <point x="449" y="1165" type="curve" smooth="yes"/>
+      <point x="338" y="1165"/>
+      <point x="266" y="1128"/>
+      <point x="225" y="1087" type="curve"/>
+      <point x="254" y="1327"/>
+      <point x="315" y="1372"/>
+      <point x="424" y="1372" type="curve" smooth="yes"/>
+      <point x="516" y="1372"/>
+      <point x="545" y="1311"/>
+      <point x="545" y="1262" type="curve"/>
+      <point x="709" y="1262" type="line"/>
+      <point x="709" y="1372"/>
+      <point x="594" y="1460"/>
+      <point x="424" y="1460" type="curve" smooth="yes"/>
+      <point x="213" y="1460"/>
+      <point x="63" y="1343"/>
+      <point x="63" y="1020" type="curve" smooth="yes"/>
+      <point x="63" y="696"/>
+      <point x="223" y="614"/>
+      <point x="399" y="614" type="curve" smooth="yes"/>
+      <point x="575" y="614"/>
+      <point x="745" y="702"/>
+    </contour>
+    <contour>
+      <point x="582" y="893" type="curve" smooth="yes"/>
+      <point x="582" y="791"/>
+      <point x="504" y="709"/>
+      <point x="406" y="709" type="curve" smooth="yes"/>
+      <point x="309" y="709"/>
+      <point x="229" y="791"/>
+      <point x="229" y="893" type="curve" smooth="yes"/>
+      <point x="229" y="995"/>
+      <point x="309" y="1079"/>
+      <point x="406" y="1079" type="curve" smooth="yes"/>
+      <point x="504" y="1079"/>
+      <point x="582" y="995"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/three.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/three.inferior.glif
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="three.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="710" y="862" type="curve" smooth="yes"/>
+      <point x="710" y="981"/>
+      <point x="603" y="1038"/>
+      <point x="522" y="1057" type="curve"/>
+      <point x="603" y="1083"/>
+      <point x="694" y="1118"/>
+      <point x="694" y="1237" type="curve" smooth="yes"/>
+      <point x="694" y="1384"/>
+      <point x="556" y="1460"/>
+      <point x="386" y="1460" type="curve" smooth="yes"/>
+      <point x="218" y="1460"/>
+      <point x="85" y="1389"/>
+      <point x="77" y="1245" type="curve"/>
+      <point x="243" y="1245" type="line"/>
+      <point x="247" y="1325"/>
+      <point x="294" y="1366"/>
+      <point x="395" y="1366" type="curve" smooth="yes"/>
+      <point x="497" y="1366"/>
+      <point x="528" y="1298"/>
+      <point x="528" y="1237" type="curve" smooth="yes"/>
+      <point x="528" y="1176"/>
+      <point x="513" y="1096"/>
+      <point x="298" y="1096" type="curve"/>
+      <point x="298" y="1006" type="line"/>
+      <point x="382" y="1006" type="line" smooth="yes"/>
+      <point x="513" y="1006"/>
+      <point x="546" y="895"/>
+      <point x="546" y="860" type="curve" smooth="yes"/>
+      <point x="546" y="772"/>
+      <point x="464" y="717"/>
+      <point x="374" y="717" type="curve" smooth="yes"/>
+      <point x="284" y="717"/>
+      <point x="225" y="772"/>
+      <point x="223" y="846" type="curve"/>
+      <point x="59" y="846" type="line"/>
+      <point x="59" y="743"/>
+      <point x="124" y="614"/>
+      <point x="366" y="614" type="curve" smooth="yes"/>
+      <point x="608" y="614"/>
+      <point x="710" y="741"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/two.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/two.inferior.glif
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="two.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="707" y="1231" type="curve" smooth="yes"/>
+      <point x="707" y="1370"/>
+      <point x="598" y="1460"/>
+      <point x="402" y="1460" type="curve" smooth="yes"/>
+      <point x="193" y="1460"/>
+      <point x="76" y="1374"/>
+      <point x="64" y="1206" type="curve"/>
+      <point x="228" y="1206" type="line"/>
+      <point x="236" y="1274"/>
+      <point x="279" y="1358"/>
+      <point x="396" y="1358" type="curve" smooth="yes"/>
+      <point x="514" y="1358"/>
+      <point x="543" y="1282"/>
+      <point x="543" y="1229" type="curve" smooth="yes"/>
+      <point x="543" y="1118"/>
+      <point x="433" y="995"/>
+      <point x="48" y="731" type="curve"/>
+      <point x="48" y="614" type="line"/>
+      <point x="691" y="614" type="line"/>
+      <point x="691" y="741" type="line"/>
+      <point x="209" y="741" type="line"/>
+      <point x="508" y="913"/>
+      <point x="707" y="1047"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/zero.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs.public.background/zero.inferior.glif
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="zero.inferior" format="2">
+  <advance width="800"/>
+  <outline>
+    <contour>
+      <point x="722" y="1036" type="curve" smooth="yes"/>
+      <point x="722" y="1270"/>
+      <point x="632" y="1460"/>
+      <point x="384" y="1460" type="curve" smooth="yes"/>
+      <point x="141" y="1460"/>
+      <point x="48" y="1270"/>
+      <point x="48" y="1036" type="curve" smooth="yes"/>
+      <point x="48" y="803"/>
+      <point x="139" y="612"/>
+      <point x="384" y="612" type="curve" smooth="yes"/>
+      <point x="634" y="612"/>
+      <point x="722" y="803"/>
+    </contour>
+    <contour>
+      <point x="554" y="1036" type="curve" smooth="yes"/>
+      <point x="554" y="860"/>
+      <point x="526" y="717"/>
+      <point x="384" y="717" type="curve" smooth="yes"/>
+      <point x="243" y="717"/>
+      <point x="214" y="860"/>
+      <point x="214" y="1036" type="curve" smooth="yes"/>
+      <point x="214" y="1212"/>
+      <point x="243" y="1356"/>
+      <point x="384" y="1356" type="curve" smooth="yes"/>
+      <point x="528" y="1356"/>
+      <point x="554" y="1212"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/contents.plist
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/contents.plist
@@ -244,8 +244,12 @@
   <string>egrave.glif</string>
   <key>eight</key>
   <string>eight.glif</string>
+  <key>eight.inferior</key>
+  <string>eight.inferior.glif</string>
   <key>eight.punct</key>
   <string>eight.punct.glif</string>
+  <key>eightcircle</key>
+  <string>eightcircle.glif</string>
   <key>eightsuperior</key>
   <string>eightsuperior.glif</string>
   <key>eightsuperior.punct</key>
@@ -280,8 +284,12 @@
   <string>figuredash.glif</string>
   <key>five</key>
   <string>five.glif</string>
+  <key>five.inferior</key>
+  <string>five.inferior.glif</string>
   <key>five.punct</key>
   <string>five.punct.glif</string>
+  <key>fivecircle</key>
+  <string>fivecircle.glif</string>
   <key>fivesuperior</key>
   <string>fivesuperior.glif</string>
   <key>fivesuperior.punct</key>
@@ -292,8 +300,12 @@
   <string>florin.glif</string>
   <key>four</key>
   <string>four.glif</string>
+  <key>four.inferior</key>
+  <string>four.inferior.glif</string>
   <key>four.punct</key>
   <string>four.punct.glif</string>
+  <key>fourcircle</key>
+  <string>fourcircle.glif</string>
   <key>foursuperior</key>
   <string>foursuperior.glif</string>
   <key>foursuperior.punct</key>
@@ -378,8 +390,12 @@
   <string>n.glif</string>
   <key>nine</key>
   <string>nine.glif</string>
+  <key>nine.inferior</key>
+  <string>nine.inferior.glif</string>
   <key>nine.punct</key>
   <string>nine.punct.glif</string>
+  <key>ninecircle</key>
+  <string>ninecircle.glif</string>
   <key>ninesuperior</key>
   <string>ninesuperior.glif</string>
   <key>ninesuperior.punct</key>
@@ -418,8 +434,12 @@
   <string>ograve.glif</string>
   <key>one</key>
   <string>one.glif</string>
+  <key>one.inferior</key>
+  <string>one.inferior.glif</string>
   <key>one.punct</key>
   <string>one.punct.glif</string>
+  <key>onecircle</key>
+  <string>onecircle.glif</string>
   <key>onehalf</key>
   <string>onehalf.glif</string>
   <key>onequarter</key>
@@ -516,16 +536,24 @@
   <string>semicolon.glif</string>
   <key>seven</key>
   <string>seven.glif</string>
+  <key>seven.inferior</key>
+  <string>seven.inferior.glif</string>
   <key>seven.punct</key>
   <string>seven.punct.glif</string>
+  <key>sevencircle</key>
+  <string>sevencircle.glif</string>
   <key>sevensuperior</key>
   <string>sevensuperior.glif</string>
   <key>sevensuperior.punct</key>
   <string>sevensuperior.punct.glif</string>
   <key>six</key>
   <string>six.glif</string>
+  <key>six.inferior</key>
+  <string>six.inferior.glif</string>
   <key>six.punct</key>
   <string>six.punct.glif</string>
+  <key>sixcircle</key>
+  <string>sixcircle.glif</string>
   <key>sixsuperior</key>
   <string>sixsuperior.glif</string>
   <key>sixsuperior.punct</key>
@@ -546,8 +574,12 @@
   <string>thorn.glif</string>
   <key>three</key>
   <string>three.glif</string>
+  <key>three.inferior</key>
+  <string>three.inferior.glif</string>
   <key>three.punct</key>
   <string>three.punct.glif</string>
+  <key>threecircle</key>
+  <string>threecircle.glif</string>
   <key>threequarters</key>
   <string>threequarters.glif</string>
   <key>threesuperior</key>
@@ -560,8 +592,12 @@
   <string>tildecomb.glif</string>
   <key>two</key>
   <string>two.glif</string>
+  <key>two.inferior</key>
+  <string>two.inferior.glif</string>
   <key>two.punct</key>
   <string>two.punct.glif</string>
+  <key>twocircle</key>
+  <string>twocircle.glif</string>
   <key>twosuperior</key>
   <string>twosuperior.glif</string>
   <key>twosuperior.punct</key>
@@ -2104,6 +2140,8 @@
   <string>zcaron.glif</string>
   <key>zero</key>
   <string>zero.glif</string>
+  <key>zero.inferior</key>
+  <string>zero.inferior.glif</string>
   <key>zero.punct</key>
   <string>zero.punct.glif</string>
   <key>zerosuperior</key>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/eight.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/eight.inferior.glif
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="eight.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2088"/>
+  <outline>
+    <contour>
+      <point x="720" y="-33" type="curve" smooth="yes"/>
+      <point x="720" y="92"/>
+      <point x="610" y="145"/>
+      <point x="534" y="173" type="curve"/>
+      <point x="591" y="203"/>
+      <point x="683" y="272"/>
+      <point x="683" y="376" type="curve" smooth="yes"/>
+      <point x="683" y="495"/>
+      <point x="563" y="586"/>
+      <point x="401" y="586" type="curve" smooth="yes"/>
+      <point x="231" y="586"/>
+      <point x="114" y="497"/>
+      <point x="114" y="356" type="curve" smooth="yes"/>
+      <point x="114" y="259"/>
+      <point x="195" y="200"/>
+      <point x="259" y="173" type="curve"/>
+      <point x="170" y="139"/>
+      <point x="79" y="77"/>
+      <point x="79" y="-35" type="curve" smooth="yes"/>
+      <point x="79" y="-180"/>
+      <point x="204" y="-278"/>
+      <point x="401" y="-278" type="curve" smooth="yes"/>
+      <point x="583" y="-278"/>
+      <point x="720" y="-178"/>
+    </contour>
+    <contour>
+      <point x="553" y="366" type="curve" smooth="yes"/>
+      <point x="553" y="290"/>
+      <point x="521" y="240"/>
+      <point x="455" y="203" type="curve"/>
+      <point x="328" y="248"/>
+      <point x="255" y="298"/>
+      <point x="255" y="384" type="curve" smooth="yes"/>
+      <point x="255" y="448"/>
+      <point x="321" y="515"/>
+      <point x="401" y="515" type="curve" smooth="yes"/>
+      <point x="479" y="515"/>
+      <point x="553" y="456"/>
+    </contour>
+    <contour>
+      <point x="575" y="-54" type="curve" smooth="yes"/>
+      <point x="575" y="-131"/>
+      <point x="505" y="-200"/>
+      <point x="401" y="-200" type="curve" smooth="yes"/>
+      <point x="282" y="-200"/>
+      <point x="212" y="-127"/>
+      <point x="212" y="-27" type="curve" smooth="yes"/>
+      <point x="212" y="61"/>
+      <point x="258" y="106"/>
+      <point x="334" y="139" type="curve"/>
+      <point x="483" y="84"/>
+      <point x="575" y="48"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/eightcircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/eightcircle.glif
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="eightcircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2467"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1257.27" y="284.405" type="curve" smooth="yes"/>
+      <point x="1257.27" y="409.405"/>
+      <point x="1147.27" y="462.405"/>
+      <point x="1071.27" y="490.405" type="curve"/>
+      <point x="1128.27" y="520.405"/>
+      <point x="1220.27" y="589.405"/>
+      <point x="1220.27" y="693.405" type="curve" smooth="yes"/>
+      <point x="1220.27" y="812.405"/>
+      <point x="1100.27" y="903.405"/>
+      <point x="938.267" y="903.405" type="curve" smooth="yes"/>
+      <point x="768.267" y="903.405"/>
+      <point x="651.267" y="814.405"/>
+      <point x="651.267" y="673.405" type="curve" smooth="yes"/>
+      <point x="651.267" y="576.405"/>
+      <point x="732.267" y="517.405"/>
+      <point x="796.267" y="490.405" type="curve"/>
+      <point x="707.267" y="456.405"/>
+      <point x="616.267" y="394.405"/>
+      <point x="616.267" y="282.405" type="curve" smooth="yes"/>
+      <point x="616.267" y="137.405"/>
+      <point x="741.267" y="39.4048"/>
+      <point x="938.267" y="39.4048" type="curve" smooth="yes"/>
+      <point x="1120.27" y="39.4048"/>
+      <point x="1257.27" y="139.405"/>
+    </contour>
+    <contour>
+      <point x="1090.27" y="683.405" type="curve" smooth="yes"/>
+      <point x="1090.27" y="607.405"/>
+      <point x="1058.27" y="557.405"/>
+      <point x="992.267" y="520.405" type="curve"/>
+      <point x="865.267" y="565.405"/>
+      <point x="792.267" y="615.405"/>
+      <point x="792.267" y="701.405" type="curve" smooth="yes"/>
+      <point x="792.267" y="765.405"/>
+      <point x="858.267" y="832.405"/>
+      <point x="938.267" y="832.405" type="curve" smooth="yes"/>
+      <point x="1016.27" y="832.405"/>
+      <point x="1090.27" y="773.405"/>
+    </contour>
+    <contour>
+      <point x="1112.27" y="263.405" type="curve" smooth="yes"/>
+      <point x="1112.27" y="186.405"/>
+      <point x="1042.27" y="117.405"/>
+      <point x="938.267" y="117.405" type="curve" smooth="yes"/>
+      <point x="819.267" y="117.405"/>
+      <point x="749.267" y="190.405"/>
+      <point x="749.267" y="290.405" type="curve" smooth="yes"/>
+      <point x="749.267" y="378.405"/>
+      <point x="795.267" y="423.405"/>
+      <point x="871.267" y="456.405" type="curve"/>
+      <point x="1020.27" y="401.405"/>
+      <point x="1112.27" y="365.405"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/five.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/five.inferior.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="five.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2085"/>
+  <outline>
+    <contour>
+      <point x="715" y="5" type="curve" smooth="yes"/>
+      <point x="715" y="162"/>
+      <point x="598" y="257"/>
+      <point x="414" y="257" type="curve" smooth="yes"/>
+      <point x="329" y="257"/>
+      <point x="251" y="229"/>
+      <point x="246" y="226" type="curve"/>
+      <point x="246" y="449" type="line"/>
+      <point x="664" y="449" type="line"/>
+      <point x="664" y="562" type="line"/>
+      <point x="140" y="562" type="line"/>
+      <point x="140" y="126" type="line"/>
+      <point x="195" y="144"/>
+      <point x="290" y="169"/>
+      <point x="353" y="169" type="curve" smooth="yes"/>
+      <point x="482" y="169"/>
+      <point x="570" y="103"/>
+      <point x="570" y="-14" type="curve" smooth="yes"/>
+      <point x="570" y="-100"/>
+      <point x="502" y="-207"/>
+      <point x="361" y="-207" type="curve" smooth="yes"/>
+      <point x="330" y="-207"/>
+      <point x="279" y="-194"/>
+      <point x="258" y="-176" type="curve"/>
+      <point x="207" y="-61" type="line"/>
+      <point x="203" y="-59"/>
+      <point x="185" y="-57"/>
+      <point x="170" y="-57" type="curve" smooth="yes"/>
+      <point x="121" y="-57"/>
+      <point x="86" y="-92"/>
+      <point x="86" y="-137" type="curve" smooth="yes"/>
+      <point x="86" y="-200"/>
+      <point x="201" y="-278"/>
+      <point x="340" y="-278" type="curve" smooth="yes"/>
+      <point x="584" y="-278"/>
+      <point x="715" y="-163"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/fivecircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/fivecircle.glif
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fivecircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2464"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1249.31" y="346" type="curve" smooth="yes"/>
+      <point x="1249.31" y="503"/>
+      <point x="1132.31" y="598"/>
+      <point x="948.314" y="598" type="curve" smooth="yes"/>
+      <point x="863.314" y="598"/>
+      <point x="785.314" y="570"/>
+      <point x="780.314" y="567" type="curve"/>
+      <point x="780.314" y="790" type="line"/>
+      <point x="1198.31" y="790" type="line"/>
+      <point x="1198.31" y="903" type="line"/>
+      <point x="674.314" y="903" type="line"/>
+      <point x="674.314" y="467" type="line"/>
+      <point x="729.314" y="485"/>
+      <point x="824.314" y="510"/>
+      <point x="887.314" y="510" type="curve" smooth="yes"/>
+      <point x="1016.31" y="510"/>
+      <point x="1104.31" y="444"/>
+      <point x="1104.31" y="327" type="curve" smooth="yes"/>
+      <point x="1104.31" y="241"/>
+      <point x="1036.31" y="134"/>
+      <point x="895.314" y="134" type="curve" smooth="yes"/>
+      <point x="864.314" y="134"/>
+      <point x="813.314" y="147"/>
+      <point x="792.314" y="165" type="curve"/>
+      <point x="741.314" y="280" type="line"/>
+      <point x="737.314" y="282"/>
+      <point x="719.314" y="284"/>
+      <point x="704.314" y="284" type="curve" smooth="yes"/>
+      <point x="655.314" y="284"/>
+      <point x="620.314" y="249"/>
+      <point x="620.314" y="204" type="curve" smooth="yes"/>
+      <point x="620.314" y="141"/>
+      <point x="735.314" y="63"/>
+      <point x="874.314" y="63" type="curve" smooth="yes"/>
+      <point x="1118.31" y="63"/>
+      <point x="1249.31" y="178"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/four.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/four.inferior.glif
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="four.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2084"/>
+  <outline>
+    <contour>
+      <point x="724" y="-42" type="line"/>
+      <point x="724" y="52" type="line"/>
+      <point x="617" y="52" type="line"/>
+      <point x="617" y="562" type="line"/>
+      <point x="506" y="562" type="line"/>
+      <point x="76" y="57" type="line"/>
+      <point x="76" y="-42" type="line"/>
+      <point x="487" y="-42" type="line"/>
+      <point x="487" y="-282" type="line"/>
+      <point x="617" y="-282" type="line"/>
+      <point x="617" y="-42" type="line"/>
+    </contour>
+    <contour>
+      <point x="487" y="52" type="line"/>
+      <point x="136" y="52" type="line"/>
+      <point x="162" y="18" type="line"/>
+      <point x="521" y="440" type="line"/>
+      <point x="487" y="451" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/fourcircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/fourcircle.glif
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fourcircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2463"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1196" y="321.214" type="line"/>
+      <point x="1196" y="415.214" type="line"/>
+      <point x="1089" y="415.214" type="line"/>
+      <point x="1089" y="925.214" type="line"/>
+      <point x="978" y="925.214" type="line"/>
+      <point x="548" y="420.214" type="line"/>
+      <point x="548" y="321.214" type="line"/>
+      <point x="959" y="321.214" type="line"/>
+      <point x="959" y="81.2136" type="line"/>
+      <point x="1089" y="81.2136" type="line"/>
+      <point x="1089" y="321.214" type="line"/>
+    </contour>
+    <contour>
+      <point x="977" y="415.214" type="line"/>
+      <point x="626" y="415.214" type="line"/>
+      <point x="652" y="381.214" type="line"/>
+      <point x="1011" y="803.214" type="line"/>
+      <point x="977" y="814.214" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/nine.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/nine.inferior.glif
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="nine.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2089"/>
+  <outline>
+    <contour>
+      <point x="78" y="287" type="curve" smooth="yes"/>
+      <point x="78" y="142"/>
+      <point x="186" y="18"/>
+      <point x="354" y="18" type="curve" smooth="yes"/>
+      <point x="430" y="18"/>
+      <point x="504" y="36"/>
+      <point x="567" y="96" type="curve"/>
+      <point x="542" y="-95"/>
+      <point x="412" y="-194"/>
+      <point x="249" y="-194" type="curve"/>
+      <point x="188" y="-194" type="line"/>
+      <point x="188" y="-278" type="line"/>
+      <point x="526" y="-278"/>
+      <point x="721" y="-86"/>
+      <point x="721" y="207" type="curve" smooth="yes"/>
+      <point x="721" y="486"/>
+      <point x="581" y="586"/>
+      <point x="401" y="586" type="curve" smooth="yes"/>
+      <point x="221" y="586"/>
+      <point x="78" y="467"/>
+    </contour>
+    <contour>
+      <point x="223" y="303" type="curve" smooth="yes"/>
+      <point x="223" y="426"/>
+      <point x="284" y="520"/>
+      <point x="401" y="520" type="curve" smooth="yes"/>
+      <point x="518" y="520"/>
+      <point x="574" y="410"/>
+      <point x="574" y="232" type="curve"/>
+      <point x="574" y="210" type="line"/>
+      <point x="574" y="198"/>
+      <point x="574" y="184"/>
+      <point x="571" y="169" type="curve"/>
+      <point x="528" y="132"/>
+      <point x="449" y="108"/>
+      <point x="401" y="108" type="curve" smooth="yes"/>
+      <point x="295" y="108"/>
+      <point x="223" y="183"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/ninecircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/ninecircle.glif
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="ninecircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2468"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="615.488" y="603.932" type="curve" smooth="yes"/>
+      <point x="615.488" y="458.932"/>
+      <point x="723.488" y="334.932"/>
+      <point x="891.488" y="334.932" type="curve" smooth="yes"/>
+      <point x="967.488" y="334.932"/>
+      <point x="1041.49" y="352.932"/>
+      <point x="1104.49" y="412.932" type="curve"/>
+      <point x="1079.49" y="221.932"/>
+      <point x="949.488" y="122.932"/>
+      <point x="786.488" y="122.932" type="curve"/>
+      <point x="725.488" y="122.932" type="line"/>
+      <point x="725.488" y="38.9321" type="line"/>
+      <point x="1063.49" y="38.9321"/>
+      <point x="1258.49" y="230.932"/>
+      <point x="1258.49" y="523.932" type="curve" smooth="yes"/>
+      <point x="1258.49" y="802.932"/>
+      <point x="1118.49" y="902.932"/>
+      <point x="938.488" y="902.932" type="curve" smooth="yes"/>
+      <point x="758.488" y="902.932"/>
+      <point x="615.488" y="783.932"/>
+    </contour>
+    <contour>
+      <point x="760.488" y="619.932" type="curve" smooth="yes"/>
+      <point x="760.488" y="742.932"/>
+      <point x="821.488" y="836.932"/>
+      <point x="938.488" y="836.932" type="curve" smooth="yes"/>
+      <point x="1055.49" y="836.932"/>
+      <point x="1111.49" y="726.932"/>
+      <point x="1111.49" y="548.932" type="curve"/>
+      <point x="1111.49" y="526.932" type="line"/>
+      <point x="1111.49" y="514.932"/>
+      <point x="1111.49" y="500.932"/>
+      <point x="1108.49" y="485.932" type="curve"/>
+      <point x="1065.49" y="448.932"/>
+      <point x="986.488" y="424.932"/>
+      <point x="938.488" y="424.932" type="curve" smooth="yes"/>
+      <point x="832.488" y="424.932"/>
+      <point x="760.488" y="499.932"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/one.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/one.inferior.glif
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="one.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2081"/>
+  <outline>
+    <contour>
+      <point x="625" y="-260" type="line"/>
+      <point x="625" y="-194" type="line"/>
+      <point x="505" y="-194" type="line" smooth="yes"/>
+      <point x="489" y="-194"/>
+      <point x="474" y="-178"/>
+      <point x="474" y="-164" type="curve" smooth="yes"/>
+      <point x="474" y="562" type="line"/>
+      <point x="410" y="562" type="line"/>
+      <point x="131" y="480" type="line"/>
+      <point x="131" y="422" type="line"/>
+      <point x="333" y="455" type="line"/>
+      <point x="333" y="-164" type="line" smooth="yes"/>
+      <point x="333" y="-178"/>
+      <point x="321" y="-190"/>
+      <point x="305" y="-190" type="curve" smooth="yes"/>
+      <point x="174" y="-190" type="line"/>
+      <point x="174" y="-260" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/onecircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/onecircle.glif
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="onecircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2460"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1163.31" y="81.2136" type="line"/>
+      <point x="1163.31" y="147.214" type="line"/>
+      <point x="1043.31" y="147.214" type="line" smooth="yes"/>
+      <point x="1027.31" y="147.214"/>
+      <point x="1012.31" y="163.214"/>
+      <point x="1012.31" y="177.214" type="curve" smooth="yes"/>
+      <point x="1012.31" y="903.214" type="line"/>
+      <point x="948.314" y="903.214" type="line"/>
+      <point x="669.314" y="821.214" type="line"/>
+      <point x="669.314" y="763.214" type="line"/>
+      <point x="871.314" y="796.214" type="line"/>
+      <point x="871.314" y="177.214" type="line" smooth="yes"/>
+      <point x="871.314" y="163.214"/>
+      <point x="859.314" y="151.214"/>
+      <point x="843.314" y="151.214" type="curve" smooth="yes"/>
+      <point x="712.314" y="151.214" type="line"/>
+      <point x="712.314" y="81.2136" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/seven.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/seven.inferior.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="seven.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2087"/>
+  <outline>
+    <contour>
+      <point x="723" y="492" type="line"/>
+      <point x="723" y="562" type="line"/>
+      <point x="76" y="562" type="line"/>
+      <point x="76" y="347" type="line"/>
+      <point x="151" y="347" type="line"/>
+      <point x="171" y="449" type="line"/>
+      <point x="624" y="449" type="line"/>
+      <point x="597" y="498" type="line"/>
+      <point x="136" y="-278" type="line"/>
+      <point x="285" y="-278" type="line"/>
+      <point x="285" y="-235" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/sevencircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/sevencircle.glif
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="sevencircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2466"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1257.93" y="833.214" type="line"/>
+      <point x="1257.93" y="903.214" type="line"/>
+      <point x="610.928" y="903.214" type="line"/>
+      <point x="610.928" y="688.214" type="line"/>
+      <point x="685.928" y="688.214" type="line"/>
+      <point x="705.928" y="790.214" type="line"/>
+      <point x="1158.93" y="790.214" type="line"/>
+      <point x="1131.93" y="839.214" type="line"/>
+      <point x="670.928" y="63.2136" type="line"/>
+      <point x="819.928" y="63.2136" type="line"/>
+      <point x="819.928" y="106.214" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/six.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/six.inferior.glif
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="six.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2086"/>
+  <outline>
+    <contour>
+      <point x="721" y="21" type="curve" smooth="yes"/>
+      <point x="721" y="166"/>
+      <point x="613" y="290"/>
+      <point x="445" y="290" type="curve" smooth="yes"/>
+      <point x="369" y="290"/>
+      <point x="295" y="272"/>
+      <point x="232" y="212" type="curve"/>
+      <point x="257" y="403"/>
+      <point x="387" y="502"/>
+      <point x="550" y="502" type="curve"/>
+      <point x="611" y="502" type="line"/>
+      <point x="611" y="586" type="line"/>
+      <point x="273" y="586"/>
+      <point x="78" y="394"/>
+      <point x="78" y="101" type="curve" smooth="yes"/>
+      <point x="78" y="-178"/>
+      <point x="218" y="-278"/>
+      <point x="398" y="-278" type="curve" smooth="yes"/>
+      <point x="578" y="-278"/>
+      <point x="721" y="-159"/>
+    </contour>
+    <contour>
+      <point x="576" y="5" type="curve" smooth="yes"/>
+      <point x="576" y="-118"/>
+      <point x="515" y="-212"/>
+      <point x="398" y="-212" type="curve" smooth="yes"/>
+      <point x="281" y="-212"/>
+      <point x="225" y="-102"/>
+      <point x="225" y="76" type="curve"/>
+      <point x="225" y="98" type="line"/>
+      <point x="225" y="110"/>
+      <point x="225" y="124"/>
+      <point x="228" y="139" type="curve"/>
+      <point x="271" y="176"/>
+      <point x="350" y="200"/>
+      <point x="398" y="200" type="curve" smooth="yes"/>
+      <point x="504" y="200"/>
+      <point x="576" y="125"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/sixcircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/sixcircle.glif
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="sixcircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2465"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1234.17" y="380.214" type="curve" smooth="yes"/>
+      <point x="1234.17" y="525.214"/>
+      <point x="1126.17" y="649.214"/>
+      <point x="958.168" y="649.214" type="curve" smooth="yes"/>
+      <point x="882.168" y="649.214"/>
+      <point x="808.168" y="631.214"/>
+      <point x="745.168" y="571.214" type="curve"/>
+      <point x="770.168" y="762.214"/>
+      <point x="900.168" y="861.214"/>
+      <point x="1063.17" y="861.214" type="curve"/>
+      <point x="1124.17" y="861.214" type="line"/>
+      <point x="1124.17" y="945.214" type="line"/>
+      <point x="786.168" y="945.214"/>
+      <point x="591.168" y="753.214"/>
+      <point x="591.168" y="460.214" type="curve" smooth="yes"/>
+      <point x="591.168" y="181.214"/>
+      <point x="731.168" y="81.2136"/>
+      <point x="911.168" y="81.2136" type="curve" smooth="yes"/>
+      <point x="1091.17" y="81.2136"/>
+      <point x="1234.17" y="200.214"/>
+    </contour>
+    <contour>
+      <point x="1089.17" y="364.214" type="curve" smooth="yes"/>
+      <point x="1089.17" y="241.214"/>
+      <point x="1028.17" y="147.214"/>
+      <point x="911.168" y="147.214" type="curve" smooth="yes"/>
+      <point x="794.168" y="147.214"/>
+      <point x="738.168" y="257.214"/>
+      <point x="738.168" y="435.214" type="curve"/>
+      <point x="738.168" y="457.214" type="line"/>
+      <point x="738.168" y="469.214"/>
+      <point x="738.168" y="483.214"/>
+      <point x="741.168" y="498.214" type="curve"/>
+      <point x="784.168" y="535.214"/>
+      <point x="863.168" y="559.214"/>
+      <point x="911.168" y="559.214" type="curve" smooth="yes"/>
+      <point x="1017.17" y="559.214"/>
+      <point x="1089.17" y="484.214"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/three.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/three.inferior.glif
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="three.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2083"/>
+  <outline>
+    <contour>
+      <point x="711" y="-26" type="curve" smooth="yes"/>
+      <point x="711" y="109"/>
+      <point x="586" y="171"/>
+      <point x="474" y="176" type="curve"/>
+      <point x="605" y="210"/>
+      <point x="676" y="287"/>
+      <point x="676" y="379" type="curve" smooth="yes"/>
+      <point x="676" y="510"/>
+      <point x="557" y="586"/>
+      <point x="404" y="586" type="curve" smooth="yes"/>
+      <point x="244" y="586"/>
+      <point x="111" y="514"/>
+      <point x="111" y="420" type="curve" smooth="yes"/>
+      <point x="111" y="367"/>
+      <point x="156" y="350"/>
+      <point x="187" y="350" type="curve" smooth="yes"/>
+      <point x="220" y="350"/>
+      <point x="240" y="363"/>
+      <point x="246" y="369" type="curve"/>
+      <point x="246" y="480" type="line"/>
+      <point x="267" y="493"/>
+      <point x="314" y="510"/>
+      <point x="367" y="510" type="curve" smooth="yes"/>
+      <point x="457" y="510"/>
+      <point x="531" y="457"/>
+      <point x="531" y="365" type="curve" smooth="yes"/>
+      <point x="531" y="261"/>
+      <point x="441" y="207"/>
+      <point x="328" y="207" type="curve" smooth="yes"/>
+      <point x="316" y="207"/>
+      <point x="299" y="208"/>
+      <point x="293" y="209" type="curve"/>
+      <point x="293" y="121" type="line"/>
+      <point x="307" y="124"/>
+      <point x="339" y="128"/>
+      <point x="373" y="128" type="curve" smooth="yes"/>
+      <point x="461" y="128"/>
+      <point x="564" y="88"/>
+      <point x="564" y="-26" type="curve" smooth="yes"/>
+      <point x="564" y="-114"/>
+      <point x="490" y="-205"/>
+      <point x="367" y="-205" type="curve" smooth="yes"/>
+      <point x="324" y="-205"/>
+      <point x="284" y="-196"/>
+      <point x="249" y="-178" type="curve"/>
+      <point x="211" y="-77" type="line"/>
+      <point x="201" y="-71"/>
+      <point x="177" y="-69"/>
+      <point x="166" y="-69" type="curve" smooth="yes"/>
+      <point x="113" y="-69"/>
+      <point x="88" y="-104"/>
+      <point x="88" y="-137" type="curve" smooth="yes"/>
+      <point x="88" y="-196"/>
+      <point x="183" y="-278"/>
+      <point x="363" y="-278" type="curve" smooth="yes"/>
+      <point x="555" y="-278"/>
+      <point x="711" y="-176"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/threecircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/threecircle.glif
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="threecircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2462"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1245.08" y="333.214" type="curve" smooth="yes"/>
+      <point x="1245.08" y="468.214"/>
+      <point x="1120.08" y="530.214"/>
+      <point x="1008.08" y="535.214" type="curve"/>
+      <point x="1139.08" y="569.214"/>
+      <point x="1210.08" y="646.214"/>
+      <point x="1210.08" y="738.214" type="curve" smooth="yes"/>
+      <point x="1210.08" y="869.214"/>
+      <point x="1091.08" y="945.214"/>
+      <point x="938.076" y="945.214" type="curve" smooth="yes"/>
+      <point x="778.076" y="945.214"/>
+      <point x="645.076" y="873.214"/>
+      <point x="645.076" y="779.214" type="curve" smooth="yes"/>
+      <point x="645.076" y="726.214"/>
+      <point x="690.076" y="709.214"/>
+      <point x="721.076" y="709.214" type="curve" smooth="yes"/>
+      <point x="754.076" y="709.214"/>
+      <point x="774.076" y="722.214"/>
+      <point x="780.076" y="728.214" type="curve"/>
+      <point x="780.076" y="839.214" type="line"/>
+      <point x="801.076" y="852.214"/>
+      <point x="848.076" y="869.214"/>
+      <point x="901.076" y="869.214" type="curve" smooth="yes"/>
+      <point x="991.076" y="869.214"/>
+      <point x="1065.08" y="816.214"/>
+      <point x="1065.08" y="724.214" type="curve" smooth="yes"/>
+      <point x="1065.08" y="620.214"/>
+      <point x="975.076" y="566.214"/>
+      <point x="862.076" y="566.214" type="curve" smooth="yes"/>
+      <point x="850.076" y="566.214"/>
+      <point x="833.076" y="567.214"/>
+      <point x="827.076" y="568.214" type="curve"/>
+      <point x="827.076" y="480.214" type="line"/>
+      <point x="841.076" y="483.214"/>
+      <point x="873.076" y="487.214"/>
+      <point x="907.076" y="487.214" type="curve" smooth="yes"/>
+      <point x="995.076" y="487.214"/>
+      <point x="1098.08" y="447.214"/>
+      <point x="1098.08" y="333.214" type="curve" smooth="yes"/>
+      <point x="1098.08" y="245.214"/>
+      <point x="1024.08" y="154.214"/>
+      <point x="901.076" y="154.214" type="curve" smooth="yes"/>
+      <point x="858.076" y="154.214"/>
+      <point x="818.076" y="163.214"/>
+      <point x="783.076" y="181.214" type="curve"/>
+      <point x="745.076" y="282.214" type="line"/>
+      <point x="735.076" y="288.214"/>
+      <point x="711.076" y="290.214"/>
+      <point x="700.076" y="290.214" type="curve" smooth="yes"/>
+      <point x="647.076" y="290.214"/>
+      <point x="622.076" y="255.214"/>
+      <point x="622.076" y="222.214" type="curve" smooth="yes"/>
+      <point x="622.076" y="163.214"/>
+      <point x="717.076" y="81.2136"/>
+      <point x="897.076" y="81.2136" type="curve" smooth="yes"/>
+      <point x="1089.08" y="81.2136"/>
+      <point x="1245.08" y="183.214"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/two.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/two.inferior.glif
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="two.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2082"/>
+  <outline>
+    <contour>
+      <point x="711" y="-260" type="line"/>
+      <point x="711" y="-47" type="line"/>
+      <point x="641" y="-47" type="line"/>
+      <point x="618" y="-147" type="line"/>
+      <point x="236" y="-147" type="line"/>
+      <point x="254" y="-135"/>
+      <point x="271.67" y="-121.557"/>
+      <point x="289" y="-109" type="curve" smooth="yes"/>
+      <point x="507.676" y="49.4477"/>
+      <point x="695" y="191"/>
+      <point x="695" y="353" type="curve" smooth="yes"/>
+      <point x="695" y="496"/>
+      <point x="570" y="586"/>
+      <point x="398" y="586" type="curve" smooth="yes"/>
+      <point x="242" y="586"/>
+      <point x="105" y="514"/>
+      <point x="105" y="410" type="curve" smooth="yes"/>
+      <point x="105" y="361"/>
+      <point x="144" y="336"/>
+      <point x="185" y="336" type="curve" smooth="yes"/>
+      <point x="215" y="336"/>
+      <point x="240" y="349"/>
+      <point x="250" y="359" type="curve"/>
+      <point x="250" y="494" type="line"/>
+      <point x="263" y="500"/>
+      <point x="309" y="520"/>
+      <point x="361" y="520" type="curve" smooth="yes"/>
+      <point x="463" y="520"/>
+      <point x="541" y="459"/>
+      <point x="541" y="340" type="curve" smooth="yes"/>
+      <point x="541" y="187"/>
+      <point x="388" y="61"/>
+      <point x="151" y="-119" type="curve"/>
+      <point x="88" y="-167" type="line"/>
+      <point x="88" y="-260" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/twocircle.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/twocircle.glif
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="twocircle" format="2">
+  <advance width="1794"/>
+  <unicode hex="2461"/>
+  <outline>
+    <contour>
+      <point x="1725" y="498" type="curve" smooth="yes"/>
+      <point x="1725" y="936"/>
+      <point x="1368" y="1290"/>
+      <point x="938" y="1290" type="curve" smooth="yes"/>
+      <point x="502" y="1290"/>
+      <point x="150" y="934"/>
+      <point x="150" y="498" type="curve" smooth="yes"/>
+      <point x="150" y="62"/>
+      <point x="504" y="-293"/>
+      <point x="934" y="-293" type="curve" smooth="yes"/>
+      <point x="1372" y="-293"/>
+      <point x="1725" y="62"/>
+    </contour>
+    <contour>
+      <point x="1636" y="498" type="curve" smooth="yes"/>
+      <point x="1636" y="113"/>
+      <point x="1323" y="-207"/>
+      <point x="936" y="-207" type="curve" smooth="yes"/>
+      <point x="549" y="-207"/>
+      <point x="238" y="111"/>
+      <point x="238" y="494" type="curve" smooth="yes"/>
+      <point x="238" y="893"/>
+      <point x="555" y="1204"/>
+      <point x="938" y="1204" type="curve" smooth="yes"/>
+      <point x="1323" y="1204"/>
+      <point x="1636" y="889"/>
+    </contour>
+    <contour>
+      <point x="1249.21" y="81.2381" type="line"/>
+      <point x="1249.21" y="294.238" type="line"/>
+      <point x="1179.21" y="294.238" type="line"/>
+      <point x="1156.21" y="194.238" type="line"/>
+      <point x="774.214" y="194.238" type="line"/>
+      <point x="792.214" y="206.238"/>
+      <point x="809.884" y="219.681"/>
+      <point x="827.214" y="232.238" type="curve" smooth="yes"/>
+      <point x="1045.89" y="390.686"/>
+      <point x="1233.21" y="532.238"/>
+      <point x="1233.21" y="694.238" type="curve" smooth="yes"/>
+      <point x="1233.21" y="837.238"/>
+      <point x="1108.21" y="927.238"/>
+      <point x="936.214" y="927.238" type="curve" smooth="yes"/>
+      <point x="780.214" y="927.238"/>
+      <point x="643.214" y="855.238"/>
+      <point x="643.214" y="751.238" type="curve" smooth="yes"/>
+      <point x="643.214" y="702.238"/>
+      <point x="682.214" y="677.238"/>
+      <point x="723.214" y="677.238" type="curve" smooth="yes"/>
+      <point x="753.214" y="677.238"/>
+      <point x="778.214" y="690.238"/>
+      <point x="788.214" y="700.238" type="curve"/>
+      <point x="788.214" y="835.238" type="line"/>
+      <point x="801.214" y="841.238"/>
+      <point x="847.214" y="861.238"/>
+      <point x="899.214" y="861.238" type="curve" smooth="yes"/>
+      <point x="1001.21" y="861.238"/>
+      <point x="1079.21" y="800.238"/>
+      <point x="1079.21" y="681.238" type="curve" smooth="yes"/>
+      <point x="1079.21" y="528.238"/>
+      <point x="926.214" y="402.238"/>
+      <point x="689.214" y="222.238" type="curve"/>
+      <point x="626.214" y="174.238" type="line"/>
+      <point x="626.214" y="81.2381" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>public.markColor</key>
+  <string>0.6,0.602,1,1</string>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/zero.inferior.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/zero.inferior.glif
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="zero.inferior" format="2">
+  <advance width="800"/>
+  <unicode hex="2080"/>
+  <outline>
+    <contour>
+      <point x="726" y="153" type="curve" smooth="yes"/>
+      <point x="726" y="399"/>
+      <point x="617" y="586"/>
+      <point x="400" y="586" type="curve" smooth="yes"/>
+      <point x="183" y="586"/>
+      <point x="73" y="399"/>
+      <point x="73" y="153" type="curve" smooth="yes"/>
+      <point x="73" y="-88"/>
+      <point x="183" y="-278"/>
+      <point x="400" y="-278" type="curve" smooth="yes"/>
+      <point x="617" y="-278"/>
+      <point x="726" y="-88"/>
+    </contour>
+    <contour>
+      <point x="575" y="153" type="curve" smooth="yes"/>
+      <point x="575" y="-37"/>
+      <point x="541" y="-207"/>
+      <point x="400" y="-207" type="curve" smooth="yes"/>
+      <point x="258" y="-207"/>
+      <point x="223" y="-37"/>
+      <point x="223" y="153" type="curve" smooth="yes"/>
+      <point x="223" y="347"/>
+      <point x="258" y="517"/>
+      <point x="400" y="517" type="curve" smooth="yes"/>
+      <point x="541" y="517"/>
+      <point x="575" y="347"/>
+    </contour>
+  </outline>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/lib.plist
+++ b/source/AbyssinicaSIL-Regular.ufo/lib.plist
@@ -2184,6 +2184,25 @@
     <string>u1E7FC</string>
     <string>u1E7FD</string>
     <string>u1E7FE</string>
+    <string>zero.inferior</string>
+    <string>one.inferior</string>
+    <string>two.inferior</string>
+    <string>three.inferior</string>
+    <string>four.inferior</string>
+    <string>five.inferior</string>
+    <string>six.inferior</string>
+    <string>seven.inferior</string>
+    <string>eight.inferior</string>
+    <string>nine.inferior</string>
+    <string>onecircle</string>
+    <string>twocircle</string>
+    <string>threecircle</string>
+    <string>fourcircle</string>
+    <string>fivecircle</string>
+    <string>sixcircle</string>
+    <string>sevencircle</string>
+    <string>eightcircle</string>
+    <string>ninecircle</string>
   </array>
   <key>public.postscriptNames</key>
   <dict>


### PR DESCRIPTION
This PR adds the subscript (aka "inferior") digits in the range U+2080 - U+2089 and the circled digits in the range U+2460 - U+2468 for consideration for inclusion with the next update of the Abyssinica SIL font.

The branch contains only the *added* `.glif` files, and corresponding updated `.plist` files that reference the added `.glif` files. The `.glif` files have been created with FontLab 8.2's export to the UFO format.