### PR TITLE
Addition of the ግዚ ligature.

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/features.fea
+++ b/source/AbyssinicaSIL-Regular.ufo/features.fea
@@ -703,6 +703,11 @@ lookup DigitAlternates {
     sub @cno_init' @cno_init by @c_init;
 } DigitAlternates;
 
+feature rlig {
+   # The g-zi ligature
+   sub uni130D uni200D uni12DA by gzi_ligature;
+} rlig;
+
 #**********************
 # Positioning lookups
 #

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/contents.plist
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/contents.plist
@@ -328,6 +328,8 @@
   <string>guilsinglright.glif</string>
   <key>guilsinglright.punct</key>
   <string>guilsinglright.punct.glif</string>
+  <key>gzi_ligature</key>
+  <string>gzi_ligature.glif</string>
   <key>h</key>
   <string>h.glif</string>
   <key>hungarumlaut</key>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/gzi_ligature.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/gzi_ligature.glif
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gzi_ligature" format="2">
+  <advance width="2223"/>
+  <outline>
+    <contour>
+      <point x="520" y="903" type="curve" smooth="yes"/>
+      <point x="520" y="817"/>
+      <point x="479" y="750"/>
+      <point x="432" y="750" type="curve" smooth="yes"/>
+      <point x="385" y="750"/>
+      <point x="354" y="780"/>
+      <point x="354" y="891" type="curve" smooth="yes"/>
+      <point x="354" y="1001"/>
+      <point x="381" y="1038"/>
+      <point x="436" y="1038" type="curve" smooth="yes"/>
+      <point x="492" y="1038"/>
+      <point x="520" y="989"/>
+    </contour>
+    <contour>
+      <point x="1210" y="941" type="line"/>
+      <point x="1210" y="1109"/>
+      <point x="1106" y="1221"/>
+      <point x="938" y="1221" type="curve" smooth="yes"/>
+      <point x="717" y="1221"/>
+      <point x="526" y="1112"/>
+      <point x="371" y="1096" type="curve" smooth="yes"/>
+      <point x="172" y="1075"/>
+      <point x="82" y="995"/>
+      <point x="82" y="846" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="158" y="641"/>
+      <point x="252" y="641" type="curve" smooth="yes"/>
+      <point x="334" y="641"/>
+      <point x="397" y="684"/>
+      <point x="463" y="695" type="curve" smooth="yes"/>
+      <point x="563" y="711"/>
+      <point x="588" y="700"/>
+      <point x="647" y="712" type="curve" smooth="yes"/>
+      <point x="707" y="725"/>
+      <point x="788" y="815"/>
+      <point x="788" y="946" type="curve" smooth="yes"/>
+      <point x="788" y="1040"/>
+      <point x="739" y="1102"/>
+      <point x="739" y="1102" type="curve"/>
+      <point x="739" y="1102"/>
+      <point x="780" y="1120"/>
+      <point x="823" y="1120" type="curve" smooth="yes"/>
+      <point x="901" y="1120"/>
+      <point x="938" y="1059"/>
+      <point x="938" y="973" type="curve" smooth="yes"/>
+      <point x="938" y="957"/>
+      <point x="937" y="939"/>
+      <point x="935" y="922" type="curve" smooth="yes"/>
+      <point x="854" y="170" type="line"/>
+      <point x="851" y="157"/>
+      <point x="848" y="120"/>
+      <point x="848" y="102" type="curve" smooth="yes"/>
+      <point x="848" y="37"/>
+      <point x="863" y="0"/>
+      <point x="924" y="0" type="curve" smooth="yes"/>
+      <point x="951" y="0"/>
+      <point x="977" y="3"/>
+      <point x="994" y="6" type="curve"/>
+      <point x="1164" y="25" type="line"/>
+      <point x="1164" y="57" type="line"/>
+      <point x="1141" y="68"/>
+      <point x="1129" y="90"/>
+      <point x="1129" y="123" type="curve" smooth="yes"/>
+      <point x="1129" y="151" type="line" smooth="yes"/>
+      <point x="1129" y="167"/>
+      <point x="1129" y="184"/>
+      <point x="1131" y="195" type="curve"/>
+      <point x="1192" y="766" type="line"/>
+      <point x="1397" y="805" type="line"/>
+      <point x="1332" y="203" type="line" smooth="yes"/>
+      <point x="1330" y="188"/>
+      <point x="1328" y="150"/>
+      <point x="1328" y="131" type="curve" smooth="yes"/>
+      <point x="1328" y="66"/>
+      <point x="1342" y="29"/>
+      <point x="1403" y="29" type="curve" smooth="yes"/>
+      <point x="1430" y="29"/>
+      <point x="1457" y="32"/>
+      <point x="1473" y="35" type="curve"/>
+      <point x="1770" y="63" type="line"/>
+      <point x="1778" y="-31"/>
+      <point x="1870" y="-70"/>
+      <point x="1971" y="-70" type="curve" smooth="yes"/>
+      <point x="2031" y="-70"/>
+      <point x="2098" y="-53"/>
+      <point x="2147" y="-37" type="curve"/>
+      <point x="2110" y="-2"/>
+      <point x="2075" y="57"/>
+      <point x="2075" y="121" type="curve" smooth="yes"/>
+      <point x="2075" y="151"/>
+      <point x="2090" y="207"/>
+      <point x="2114" y="248" type="curve"/>
+      <point x="2107" y="249"/>
+      <point x="2100" y="251"/>
+      <point x="2092" y="253" type="curve" smooth="yes"/>
+      <point x="2077" y="256"/>
+      <point x="2059" y="258"/>
+      <point x="2036" y="258" type="curve" smooth="yes"/>
+      <point x="1900" y="258"/>
+      <point x="1826" y="224"/>
+      <point x="1772" y="141" type="curve"/>
+      <point x="1753" y="139"/>
+      <point x="1736" y="137"/>
+      <point x="1720" y="136" type="curve" smooth="yes"/>
+      <point x="1693" y="133"/>
+      <point x="1662" y="131"/>
+      <point x="1651" y="131" type="curve" smooth="yes"/>
+      <point x="1611" y="131"/>
+      <point x="1607" y="153"/>
+      <point x="1607" y="180" type="curve" smooth="yes"/>
+      <point x="1607" y="203" type="line" smooth="yes"/>
+      <point x="1607" y="212"/>
+      <point x="1607" y="221"/>
+      <point x="1688" y="969" type="curve" smooth="yes"/>
+      <point x="1691" y="1000"/>
+      <point x="1696" y="1054"/>
+      <point x="1696" y="1114" type="curve" smooth="yes"/>
+      <point x="1696" y="1163"/>
+      <point x="1678" y="1233"/>
+      <point x="1606" y="1233" type="curve" smooth="yes"/>
+      <point x="1586" y="1233"/>
+      <point x="1572" y="1232"/>
+      <point x="1545" y="1225" type="curve"/>
+      <point x="1371" y="1190" type="line"/>
+      <point x="1371" y="1155" type="line"/>
+      <point x="1412" y="1128"/>
+      <point x="1424" y="1108"/>
+      <point x="1424" y="1073" type="curve"/>
+      <point x="1405" y="879" type="line"/>
+      <point x="1201" y="842" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+  <dict>
+  <key>note</key>
+  <real>0</real>
+  </dict>
+  </lib>
+</glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/lib.plist
+++ b/source/AbyssinicaSIL-Regular.ufo/lib.plist
@@ -2184,6 +2184,7 @@
     <string>u1E7FC</string>
     <string>u1E7FD</string>
     <string>u1E7FE</string>
+    <string>gzi_ligature</string>
   </array>
   <key>public.postscriptNames</key>
   <dict>


### PR DESCRIPTION
This branch contains the minimal additions necessary to provide the "ግዚ".  The ግዚ ligature is by far the most frequently found and familiar ligature in Ethiopic manuscripts.

### Notes
* The left and right side readings of the glyph borrow from the left sidebearing of ግ and the right sightbearing of ዚ.
* The ligature is implemented with the following feature, which in turn applies the Zero-width Joiner (ZWJ, U+200D) mark to indicate the ligation:

```
feature rlig {
   # The g-zi ligature
   sub uni130D uni200D uni12DA by gzi_ligature;
} rlig;
```

* Image example from the attached test document:

 ![Ethiopic-gzi-ligature](https://github.com/silnrsi/font-abyssinica/assets/8098333/b2ca7c09-f8ec-4d7d-a2c2-ddd05c0f25e5)

* Test document: [EthiopicLigatureTest.docx](https://github.com/silnrsi/font-abyssinica/files/14620810/EthiopicLigatureTest.docx)
