### PR TITLE
Redesigned ሔ Diacritical Mark

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/u1E_7E_4.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/u1E_7E_4.glif
@@ -5,26 +5,9 @@
   <anchor x="920" y="1423" name="U"/>
   <outline>
     <contour>
-      <point x="1612" y="203" type="curve" smooth="yes"/>
-      <point x="1612" y="161"/>
-      <point x="1589" y="94"/>
-      <point x="1538" y="94" type="curve" smooth="yes"/>
-      <point x="1498" y="94"/>
-      <point x="1491" y="128"/>
-      <point x="1491" y="160" type="curve" smooth="yes"/>
-      <point x="1491" y="211"/>
-      <point x="1487" y="262"/>
-      <point x="1483" y="313" type="curve"/>
-      <point x="1499" y="315"/>
-      <point x="1514" y="315"/>
-      <point x="1530" y="315" type="curve" smooth="yes"/>
-      <point x="1589" y="315"/>
-      <point x="1612" y="253"/>
-    </contour>
-    <contour>
-      <point x="1884" y="223" type="curve" smooth="yes"/>
-      <point x="1884" y="342"/>
-      <point x="1827" y="410"/>
+      <point x="1889" y="240" type="curve" smooth="yes"/>
+      <point x="1889" y="372"/>
+      <point x="1821" y="410"/>
       <point x="1700" y="410" type="curve" smooth="yes"/>
       <point x="1610" y="410"/>
       <point x="1542" y="383"/>
@@ -117,7 +100,7 @@
       <point x="922" y="145" type="curve" smooth="yes"/>
       <point x="922" y="164"/>
       <point x="926" y="209"/>
-      <point x="928" y="227" type="curve" smooth="yes"/>
+      <point x="928" y="227" type="curve"/>
       <point x="987" y="653" type="line"/>
       <point x="1108" y="653"/>
       <point x="1180" y="600"/>
@@ -129,9 +112,26 @@
       <point x="1389" y="0"/>
       <point x="1466" y="27"/>
       <point x="1520" y="27" type="curve" smooth="yes"/>
-      <point x="1626" y="27" type="line" smooth="yes"/>
-      <point x="1726" y="27"/>
-      <point x="1884" y="74"/>
+      <point x="1618" y="27" type="line" smooth="yes"/>
+      <point x="1740" y="27"/>
+      <point x="1889" y="102"/>
+    </contour>
+    <contour>
+      <point x="1654" y="208" type="curve" smooth="yes"/>
+      <point x="1654" y="143"/>
+      <point x="1621" y="87"/>
+      <point x="1551" y="87" type="curve" smooth="yes"/>
+      <point x="1492" y="87"/>
+      <point x="1489" y="132"/>
+      <point x="1489" y="181" type="curve" smooth="yes"/>
+      <point x="1489" y="211"/>
+      <point x="1485.9" y="261.879"/>
+      <point x="1483" y="313" type="curve"/>
+      <point x="1500" y="316"/>
+      <point x="1537" y="322"/>
+      <point x="1554" y="322" type="curve" smooth="yes"/>
+      <point x="1627" y="322"/>
+      <point x="1654" y="275"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/u1E_7E_A_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/u1E_7E_A_.glif
@@ -5,23 +5,6 @@
   <anchor x="900" y="1273" name="U"/>
   <outline>
     <contour>
-      <point x="1621" y="142" type="curve" smooth="yes"/>
-      <point x="1621" y="100"/>
-      <point x="1598" y="33"/>
-      <point x="1547" y="33" type="curve" smooth="yes"/>
-      <point x="1507" y="33"/>
-      <point x="1500" y="67"/>
-      <point x="1500" y="99" type="curve" smooth="yes"/>
-      <point x="1500" y="140"/>
-      <point x="1494" y="201"/>
-      <point x="1492" y="242" type="curve"/>
-      <point x="1508" y="244"/>
-      <point x="1523" y="244"/>
-      <point x="1539" y="244" type="curve" smooth="yes"/>
-      <point x="1598" y="244"/>
-      <point x="1621" y="192"/>
-    </contour>
-    <contour>
       <point x="1926" y="636" type="curve" smooth="yes"/>
       <point x="1926" y="577"/>
       <point x="1909" y="521"/>
@@ -148,6 +131,23 @@
       <point x="1718" y="792"/>
       <point x="1641" y="781"/>
       <point x="1597" y="728" type="curve"/>
+    </contour>
+    <contour>
+      <point x="1663" y="137" type="curve" smooth="yes"/>
+      <point x="1663" y="72"/>
+      <point x="1630" y="16"/>
+      <point x="1560" y="16" type="curve" smooth="yes"/>
+      <point x="1501" y="16"/>
+      <point x="1498" y="61"/>
+      <point x="1498" y="110" type="curve" smooth="yes"/>
+      <point x="1498" y="140"/>
+      <point x="1494.9" y="190.879"/>
+      <point x="1492" y="242" type="curve"/>
+      <point x="1509" y="245"/>
+      <point x="1546" y="251"/>
+      <point x="1563" y="251" type="curve" smooth="yes"/>
+      <point x="1636" y="251"/>
+      <point x="1663" y="204"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1214.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1214.glif
@@ -5,9 +5,9 @@
   <anchor x="900" y="1273" name="U"/>
   <outline>
     <contour>
-      <point x="1884" y="223" type="curve" smooth="yes"/>
-      <point x="1884" y="345"/>
-      <point x="1824" y="410"/>
+      <point x="1889" y="240" type="curve" smooth="yes"/>
+      <point x="1889" y="372"/>
+      <point x="1821" y="410"/>
       <point x="1700" y="410" type="curve" smooth="yes"/>
       <point x="1624" y="410"/>
       <point x="1553" y="384"/>
@@ -82,26 +82,26 @@
       <point x="1383" y="0"/>
       <point x="1451" y="27"/>
       <point x="1520" y="27" type="curve" smooth="yes"/>
-      <point x="1626" y="27" type="line" smooth="yes"/>
-      <point x="1745" y="27"/>
-      <point x="1884" y="85"/>
+      <point x="1618" y="27" type="line" smooth="yes"/>
+      <point x="1740" y="27"/>
+      <point x="1889" y="102"/>
     </contour>
     <contour>
-      <point x="1612" y="203" type="curve" smooth="yes"/>
-      <point x="1612" y="161"/>
-      <point x="1589" y="94"/>
-      <point x="1538" y="94" type="curve" smooth="yes"/>
-      <point x="1498" y="94"/>
-      <point x="1489" y="128"/>
-      <point x="1489" y="160" type="curve" smooth="yes"/>
+      <point x="1654" y="208" type="curve" smooth="yes"/>
+      <point x="1654" y="143"/>
+      <point x="1621" y="87"/>
+      <point x="1551" y="87" type="curve" smooth="yes"/>
+      <point x="1492" y="87"/>
+      <point x="1489" y="132"/>
+      <point x="1489" y="181" type="curve" smooth="yes"/>
       <point x="1489" y="211"/>
-      <point x="1486" y="262"/>
+      <point x="1485.9" y="261.879"/>
       <point x="1483" y="313" type="curve"/>
-      <point x="1499" y="315"/>
-      <point x="1514" y="315"/>
-      <point x="1530" y="315" type="curve" smooth="yes"/>
-      <point x="1589" y="315"/>
-      <point x="1612" y="253"/>
+      <point x="1500" y="316"/>
+      <point x="1537" y="322"/>
+      <point x="1554" y="322" type="curve" smooth="yes"/>
+      <point x="1627" y="322"/>
+      <point x="1654" y="275"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
This pull request modifies only the letters ሔ, 𞟤, and 𞟪 .  The ሔ diacritical mark is redesigned so the "loop" in the foot is a little larger.   ሔ is an important letter given its regularity from the Amharic, Tigrinya, and Ge'ez word for God, እግዚአብሔር, so the greater clarity from the larger loop should be beneficial.  The loop does seem a little small compared to other letters in the 5th order.

Some notes:

* The loop from the mark from the ጤ diacritic is applied to ሔ, the outer loop is also applied to maintain the distance from the inner and outer loops walls. 
* The above reduces the right side bearing from a value of 82 to 77. 
*  Maintaining the "82" value would increase the letter width, as well as word width, and would break the layout of existing documents.  Whereas at 77 the letter width remains the same. 82 is a little large, 55 is more common.
* The screenshot compares the ሔ between the current and modified glyph in some word samples, as well as against similar letter.
* The screenshot also shows that the ዜ diacritical mark is similarly a bit small when compared to other letters and its derived glyph in "zh", ዤ .

<img width="953" alt="AbyssinicaSIL-New-Hie" src="https://github.com/silnrsi/font-abyssinica/assets/8098333/70459993-238a-4a75-b744-3bf24e3df46e">
