### PR TITLE
Stackable Combining Marks

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/acutecomb.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/acutecomb.glif
@@ -2,6 +2,7 @@
 <glyph name="acutecomb" format="2">
   <unicode hex="0301"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1981" name="U"/>
   <outline>
     <contour>
       <point x="-573" y="1839" type="curve" smooth="yes"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/gravecomb.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/gravecomb.glif
@@ -2,6 +2,7 @@
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1981" name="U"/>
   <outline>
     <contour>
       <point x="-725" y="1558" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/tildecomb.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/tildecomb.glif
@@ -2,6 +2,7 @@
 <glyph name="tildecomb" format="2">
   <unicode hex="0303"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1862" name="U"/>
   <outline>
     <contour>
       <point x="-601" y="1812" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0302.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0302.glif
@@ -2,6 +2,7 @@
 <glyph name="uni0302" format="2">
   <unicode hex="0302"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1986" name="U"/>
   <outline>
     <contour>
       <point x="-535" y="1589" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0304.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0304.glif
@@ -2,6 +2,7 @@
 <glyph name="uni0304" format="2">
   <unicode hex="0304"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1790" name="U"/>
   <outline>
     <contour>
       <point x="-524" y="1610" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0307.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0307.glif
@@ -2,6 +2,7 @@
 <glyph name="uni0307" format="2">
   <unicode hex="0307"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1848" name="U"/>
   <outline>
     <contour>
       <point x="-869" y="1798" type="curve" smooth="yes"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0308.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni0308.glif
@@ -2,6 +2,7 @@
 <glyph name="uni0308" format="2">
   <unicode hex="0308"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1848" name="U"/>
   <outline>
     <contour>
       <point x="-996" y="1776" type="curve" smooth="yes"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030B_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030B_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni030B" format="2">
   <unicode hex="030B"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1981" name="U"/>
   <outline>
     <contour>
       <point x="-326" y="1839" type="curve" smooth="yes"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030C_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni030C" format="2">
   <unicode hex="030C"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1975" name="U"/>
   <outline>
     <contour>
       <point x="-534" y="1925" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030F_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni030F_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni030F" format="2">
   <unicode hex="030F"/>
   <anchor x="-830" y="1450" name="_U"/>
+  <anchor x="-830" y="1981" name="U"/>
   <outline>
     <contour>
       <point x="-558" y="1558" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135D_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135D_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni135D" format="2">
   <unicode hex="135D"/>
   <anchor x="-547" y="1451" name="_U"/>
+  <anchor x="-547" y="1916" name="U"/>
   <outline>
     <contour>
       <point x="-420" y="1595" type="curve"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135E_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135E_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni135E" format="2">
   <unicode hex="135E"/>
   <anchor x="-547" y="1464" name="_U"/>
+  <anchor x="-547" y="1875" name="U"/>
   <outline>
     <contour>
       <point x="-415" y="1825" type="line"/>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135F_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni135F_.glif
@@ -2,6 +2,7 @@
 <glyph name="uni135F" format="2">
   <unicode hex="135F"/>
   <anchor x="-546" y="1450" name="_U"/>
+  <anchor x="-546" y="1875" name="U"/>
   <outline>
     <contour>
       <point x="-176" y="1595" type="curve"/>


### PR DESCRIPTION
This update adds anchor to combining marks to allow them stack upon one another should they occur in a string of characters.  While the result is considered linguistically invalid, the advantage to having the marks stack up vertically allows the user to detect the error and make the appropriate correction.  The stacking presentation of the marks helps illuminate the error better in comparison to the current behavior where they the marks will superimpose upon one another.  This is believed to be the modern norm and best practice for the marks.

Marks that have been given the extra anchor for combining:

- U+0300
- U+0301
- U+0302
- U+0303
- U+0304
- U+0307
- U+0308
- U+030B
- U+030C
- U+030F
- U+135D
- U+135E
- U+135F

A screenshot that demonstrates the stacking effect:

<img width="494" alt="Screenshot 2024-09-23 at 3 38 42 PM" src="https://github.com/user-attachments/assets/bd15c406-aae1-4afa-ae99-4995e754b9f5">
