### PR TITLE
Enhancements to 5th Form Diacritic Marks for 8 Letters

### DIFF
--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/gzi.ligature.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/gzi.ligature.glif
@@ -135,10 +135,4 @@
       <point x="1201" y="842" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>note</key>
-      <integer>0</integer>
-    </dict>
-  </lib>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1264.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1264.glif
@@ -5,21 +5,9 @@
   <anchor x="568" y="1328" name="U"/>
   <outline>
     <contour>
-      <point x="1386" y="203" type="curve" smooth="yes"/>
-      <point x="1386" y="301"/>
-      <point x="1305" y="369"/>
       <point x="1210" y="369" type="curve" smooth="yes"/>
-      <point x="1184" y="369"/>
-      <point x="1166" y="367"/>
-      <point x="1140" y="363" type="curve" smooth="yes"/>
-      <point x="1120" y="360"/>
-      <point x="1100" y="352"/>
-      <point x="1079" y="352" type="curve" smooth="yes"/>
-      <point x="1053" y="352"/>
-      <point x="1029" y="367"/>
-      <point x="1004" y="367" type="curve" smooth="yes"/>
-      <point x="986" y="367"/>
-      <point x="967" y="362"/>
+      <point x="1130" y="370"/>
+      <point x="1031" y="356"/>
       <point x="950" y="356" type="curve"/>
       <point x="950" y="542"/>
       <point x="967" y="727"/>
@@ -74,20 +62,26 @@
       <point x="1174" y="-14" type="curve" smooth="yes"/>
       <point x="1295" y="-14"/>
       <point x="1386" y="83"/>
+      <point x="1386" y="203" type="curve" smooth="yes"/>
+      <point x="1386" y="301"/>
+      <point x="1304.99" y="367.813"/>
     </contour>
     <contour>
-      <point x="1126" y="182" type="curve" smooth="yes"/>
-      <point x="1126" y="122"/>
-      <point x="1093" y="53"/>
-      <point x="1024" y="53" type="curve" smooth="yes"/>
-      <point x="963" y="53"/>
-      <point x="928" y="95"/>
-      <point x="928" y="154" type="curve" smooth="yes"/>
-      <point x="928" y="241"/>
-      <point x="929" y="297"/>
-      <point x="1030" y="297" type="curve" smooth="yes"/>
-      <point x="1098" y="297"/>
-      <point x="1126" y="244"/>
+      <point x="1125" y="180" type="curve" smooth="yes"/>
+      <point x="1125" y="105"/>
+      <point x="1074.16" y="53.8711"/>
+      <point x="1004.16" y="55" type="curve" smooth="yes"/>
+      <point x="942.165" y="56"/>
+      <point x="942.165" y="99"/>
+      <point x="942.165" y="148" type="curve" smooth="yes"/>
+      <point x="942.165" y="193"/>
+      <point x="943.165" y="242.584"/>
+      <point x="947" y="289" type="curve"/>
+      <point x="964" y="292"/>
+      <point x="991.183" y="289.797"/>
+      <point x="1008.16" y="289" type="curve" smooth="yes"/>
+      <point x="1082.49" y="285.512"/>
+      <point x="1125" y="251.627"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni126C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni126C_.glif
@@ -45,21 +45,6 @@
       <point x="1198" y="1185"/>
     </contour>
     <contour>
-      <point x="1466" y="229" type="curve" smooth="yes"/>
-      <point x="1466" y="327"/>
-      <point x="1385" y="395"/>
-      <point x="1290" y="395" type="curve" smooth="yes"/>
-      <point x="1262" y="395"/>
-      <point x="1235" y="392"/>
-      <point x="1208" y="387" type="curve" smooth="yes"/>
-      <point x="1192" y="384"/>
-      <point x="1176" y="379"/>
-      <point x="1159" y="379" type="curve" smooth="yes"/>
-      <point x="1133" y="379"/>
-      <point x="1109" y="393"/>
-      <point x="1083" y="393" type="curve" smooth="yes"/>
-      <point x="1062" y="393"/>
-      <point x="1042" y="389"/>
       <point x="1022" y="383" type="curve"/>
       <point x="1022" y="443"/>
       <point x="1030" y="620"/>
@@ -81,7 +66,7 @@
       <point x="288" y="1" type="curve" smooth="yes"/>
       <point x="300" y="1"/>
       <point x="312" y="3"/>
-      <point x="324" y="4" type="curve" smooth="yes"/>
+      <point x="324" y="4" type="curve"/>
       <point x="530" y="29" type="line"/>
       <point x="530" y="55" type="line"/>
       <point x="510" y="62"/>
@@ -113,20 +98,29 @@
       <point x="1253" y="12" type="curve" smooth="yes"/>
       <point x="1374" y="12"/>
       <point x="1466" y="109"/>
+      <point x="1466" y="229" type="curve" smooth="yes"/>
+      <point x="1466" y="327"/>
+      <point x="1384.99" y="393.813"/>
+      <point x="1290" y="395" type="curve" smooth="yes"/>
+      <point x="1210" y="396"/>
+      <point x="1111" y="382"/>
     </contour>
     <contour>
-      <point x="1206" y="209" type="curve" smooth="yes"/>
-      <point x="1206" y="148"/>
-      <point x="1173" y="80"/>
-      <point x="1104" y="80" type="curve" smooth="yes"/>
-      <point x="1043" y="80"/>
-      <point x="1008" y="120"/>
-      <point x="1008" y="180" type="curve" smooth="yes"/>
-      <point x="1008" y="267"/>
-      <point x="1009" y="324"/>
-      <point x="1110" y="324" type="curve" smooth="yes"/>
-      <point x="1178" y="324"/>
-      <point x="1206" y="270"/>
+      <point x="1205" y="206" type="curve" smooth="yes"/>
+      <point x="1205" y="131"/>
+      <point x="1154.16" y="79.8711"/>
+      <point x="1084.16" y="81" type="curve" smooth="yes"/>
+      <point x="1022.16" y="82"/>
+      <point x="1022.16" y="125"/>
+      <point x="1022.16" y="174" type="curve" smooth="yes"/>
+      <point x="1022.16" y="219"/>
+      <point x="1023.16" y="268.584"/>
+      <point x="1027" y="315" type="curve"/>
+      <point x="1044" y="318"/>
+      <point x="1071.18" y="315.797"/>
+      <point x="1088.16" y="315" type="curve" smooth="yes"/>
+      <point x="1162.49" y="311.512"/>
+      <point x="1205" y="277.627"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni129C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni129C_.glif
@@ -5,6 +5,45 @@
   <anchor x="689" y="1416" name="U"/>
   <outline>
     <contour>
+      <point x="569" y="211" type="curve"/>
+      <point x="558.118" y="189.938"/>
+      <point x="536" y="146"/>
+      <point x="536" y="123" type="curve" smooth="yes"/>
+      <point x="536" y="29"/>
+      <point x="607" y="1"/>
+      <point x="691" y="1" type="curve" smooth="yes"/>
+      <point x="707" y="1"/>
+      <point x="723.014" y="1.8933"/>
+      <point x="739" y="4" type="curve" smooth="yes"/>
+      <point x="852.014" y="18.8933"/>
+      <point x="969" y="31"/>
+      <point x="1083" y="31" type="curve" smooth="yes"/>
+      <point x="1236" y="31"/>
+      <point x="1364.52" y="109.689"/>
+      <point x="1355" y="279" type="curve" smooth="yes"/>
+      <point x="1350.51" y="358.874"/>
+      <point x="1312" y="410"/>
+      <point x="1230" y="410" type="curve" smooth="yes"/>
+      <point x="1189" y="410"/>
+      <point x="1062" y="399"/>
+      <point x="964" y="393" type="curve"/>
+      <point x="1139" y="762" type="line" smooth="yes"/>
+      <point x="1148.97" y="783.016"/>
+      <point x="1163" y="828"/>
+      <point x="1163" y="852" type="curve" smooth="yes"/>
+      <point x="1163" y="884"/>
+      <point x="1146" y="901"/>
+      <point x="1114" y="901" type="curve" smooth="yes"/>
+      <point x="1063" y="901"/>
+      <point x="873" y="881"/>
+      <point x="768" y="870" type="curve"/>
+      <point x="823" y="1207" type="line"/>
+      <point x="969" y="1217" type="line"/>
+      <point x="990" y="1145"/>
+      <point x="1068" y="1106"/>
+      <point x="1139" y="1106" type="curve" smooth="yes"/>
+      <point x="1196" y="1106"/>
+      <point x="1328" y="1117"/>
       <point x="1370" y="1159" type="curve"/>
       <point x="1329" y="1191"/>
       <point x="1280" y="1257"/>
@@ -50,63 +89,24 @@
       <point x="586" y="778" type="curve" smooth="yes"/>
       <point x="856" y="805" type="line"/>
       <point x="761" y="604"/>
-      <point x="661" y="404"/>
-      <point x="563" y="199" type="curve" smooth="yes"/>
-      <point x="540" y="151"/>
-      <point x="535" y="128"/>
-      <point x="535" y="76" type="curve" smooth="yes"/>
-      <point x="535" y="19"/>
-      <point x="555" y="0"/>
-      <point x="610" y="0" type="curve" smooth="yes"/>
-      <point x="679" y="0"/>
-      <point x="747" y="31"/>
-      <point x="815" y="31" type="curve" smooth="yes"/>
-      <point x="866" y="31"/>
-      <point x="918" y="25"/>
-      <point x="969" y="25" type="curve" smooth="yes"/>
-      <point x="1110" y="25"/>
-      <point x="1270" y="91"/>
-      <point x="1270" y="254" type="curve" smooth="yes"/>
-      <point x="1270" y="323"/>
-      <point x="1228" y="383"/>
-      <point x="1155" y="383" type="curve" smooth="yes"/>
-      <point x="1107" y="383"/>
-      <point x="1017" y="372"/>
-      <point x="950" y="365" type="curve"/>
-      <point x="1139" y="762" type="line" smooth="yes"/>
-      <point x="1149" y="783"/>
-      <point x="1163" y="828"/>
-      <point x="1163" y="852" type="curve" smooth="yes"/>
-      <point x="1163" y="884"/>
-      <point x="1146" y="901"/>
-      <point x="1114" y="901" type="curve" smooth="yes"/>
-      <point x="1063" y="901"/>
-      <point x="873" y="881"/>
-      <point x="768" y="870" type="curve"/>
-      <point x="823" y="1207" type="line"/>
-      <point x="969" y="1217" type="line"/>
-      <point x="990" y="1145"/>
-      <point x="1068" y="1106"/>
-      <point x="1139" y="1106" type="curve" smooth="yes"/>
-      <point x="1196" y="1106"/>
-      <point x="1328" y="1117"/>
+      <point x="667" y="416"/>
     </contour>
     <contour>
-      <point x="997" y="215" type="curve" smooth="yes"/>
-      <point x="997" y="163"/>
-      <point x="959" y="94"/>
-      <point x="901" y="94" type="curve" smooth="yes"/>
-      <point x="884" y="94"/>
-      <point x="848" y="100"/>
-      <point x="848" y="123" type="curve" smooth="yes"/>
-      <point x="848" y="161"/>
-      <point x="901" y="258"/>
-      <point x="915" y="287" type="curve"/>
-      <point x="927" y="289"/>
-      <point x="940" y="289"/>
-      <point x="952" y="289" type="curve" smooth="yes"/>
-      <point x="985" y="289"/>
-      <point x="997" y="241"/>
+      <point x="1097" y="240" type="curve" smooth="yes"/>
+      <point x="1097" y="145"/>
+      <point x="1014" y="94"/>
+      <point x="927" y="94" type="curve" smooth="yes"/>
+      <point x="889" y="94"/>
+      <point x="837" y="101"/>
+      <point x="837" y="150" type="curve" smooth="yes"/>
+      <point x="837" y="165"/>
+      <point x="917" y="309"/>
+      <point x="927" y="328" type="curve"/>
+      <point x="947" y="328"/>
+      <point x="967" y="330"/>
+      <point x="987" y="330" type="curve" smooth="yes"/>
+      <point x="1040" y="330"/>
+      <point x="1097" y="300"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni12D_C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni12D_C_.glif
@@ -5,15 +5,9 @@
   <anchor x="594" y="1257" name="U"/>
   <outline>
     <contour>
-      <point x="1298" y="268" type="curve" smooth="yes"/>
-      <point x="1298" y="363"/>
-      <point x="1246" y="434"/>
-      <point x="1147" y="434" type="curve" smooth="yes"/>
-      <point x="1087" y="434"/>
-      <point x="1005" y="421"/>
-      <point x="936" y="408" type="curve"/>
+      <point x="932" y="385" type="curve"/>
       <point x="1001" y="975" type="line" smooth="yes"/>
-      <point x="1007" y="1023"/>
+      <point x="1006.62" y="1023.05"/>
       <point x="1010" y="1071"/>
       <point x="1010" y="1120" type="curve" smooth="yes"/>
       <point x="1010" y="1177"/>
@@ -67,36 +61,42 @@
       <point x="711" y="809" type="line"/>
       <point x="637" y="174" type="line" smooth="yes"/>
       <point x="634" y="150"/>
-      <point x="633" y="126"/>
-      <point x="633" y="102" type="curve" smooth="yes"/>
-      <point x="633" y="27"/>
-      <point x="652" y="0"/>
+      <point x="633" y="127"/>
+      <point x="633" y="103" type="curve" smooth="yes"/>
+      <point x="633" y="28"/>
+      <point x="651" y="0"/>
       <point x="731" y="0" type="curve" smooth="yes"/>
-      <point x="810" y="0"/>
-      <point x="878" y="51"/>
-      <point x="956" y="51" type="curve" smooth="yes"/>
-      <point x="997" y="51"/>
-      <point x="1037" y="39"/>
-      <point x="1079" y="39" type="curve" smooth="yes"/>
-      <point x="1190" y="39"/>
-      <point x="1298" y="159"/>
+      <point x="806" y="0"/>
+      <point x="877" y="29"/>
+      <point x="952" y="29" type="curve" smooth="yes"/>
+      <point x="1000" y="29"/>
+      <point x="1047" y="15"/>
+      <point x="1096" y="15" type="curve" smooth="yes"/>
+      <point x="1218" y="15"/>
+      <point x="1298" y="123"/>
+      <point x="1298" y="254" type="curve" smooth="yes"/>
+      <point x="1298" y="373"/>
+      <point x="1224" y="410"/>
+      <point x="1116" y="410" type="curve" smooth="yes"/>
+      <point x="1103" y="410"/>
+      <point x="1017" y="389"/>
     </contour>
     <contour>
-      <point x="1026" y="236" type="curve" smooth="yes"/>
-      <point x="1026" y="188"/>
-      <point x="1015" y="121"/>
-      <point x="954" y="121" type="curve" smooth="yes"/>
-      <point x="928" y="121"/>
-      <point x="907" y="128"/>
-      <point x="907" y="158" type="curve" smooth="yes"/>
-      <point x="907" y="192"/>
-      <point x="917" y="282"/>
-      <point x="928" y="342" type="curve"/>
-      <point x="936" y="343"/>
-      <point x="944" y="343"/>
-      <point x="952" y="343" type="curve" smooth="yes"/>
-      <point x="999" y="343"/>
-      <point x="1026" y="329"/>
+      <point x="1094" y="219" type="curve" smooth="yes"/>
+      <point x="1094" y="150.047"/>
+      <point x="1043.13" y="97"/>
+      <point x="977" y="97" type="curve" smooth="yes"/>
+      <point x="954" y="97"/>
+      <point x="911" y="104"/>
+      <point x="911" y="135" type="curve" smooth="yes"/>
+      <point x="911" y="174"/>
+      <point x="916" y="251"/>
+      <point x="924" y="307" type="curve"/>
+      <point x="953" y="318"/>
+      <point x="979" y="322"/>
+      <point x="1010" y="322" type="curve" smooth="yes"/>
+      <point x="1081" y="322"/>
+      <point x="1094" y="284"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1334.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni1334.glif
@@ -100,21 +100,21 @@
       <point x="694" y="1041"/>
     </contour>
     <contour>
-      <point x="1190" y="162" type="curve" smooth="yes"/>
-      <point x="1190" y="127"/>
-      <point x="1182" y="92"/>
+      <point x="1227.59" y="201.832" type="curve" smooth="yes"/>
+      <point x="1227.25" y="144.776"/>
+      <point x="1197.51" y="92"/>
       <point x="1139" y="92" type="curve" smooth="yes"/>
       <point x="1093" y="92"/>
-      <point x="1075" y="140"/>
+      <point x="1075.25" y="140.015"/>
       <point x="1070" y="224" type="curve" smooth="yes"/>
-      <point x="1068" y="252"/>
+      <point x="1068.25" y="252.017"/>
       <point x="1063" y="280"/>
       <point x="1057" y="307" type="curve"/>
-      <point x="1072" y="311"/>
-      <point x="1088" y="315"/>
-      <point x="1104" y="315" type="curve" smooth="yes"/>
-      <point x="1175" y="315"/>
-      <point x="1190" y="215"/>
+      <point x="1074" y="309.733"/>
+      <point x="1111.59" y="315.832"/>
+      <point x="1127.59" y="315.832" type="curve" smooth="yes"/>
+      <point x="1200.59" y="315.832"/>
+      <point x="1228" y="269"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uni133C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uni133C_.glif
@@ -85,18 +85,18 @@
       <point x="578" y="1075"/>
     </contour>
     <contour>
-      <point x="1130" y="162" type="curve" smooth="yes"/>
-      <point x="1130" y="127"/>
-      <point x="1122" y="92"/>
-      <point x="1079" y="92" type="curve" smooth="yes"/>
-      <point x="1003" y="92"/>
-      <point x="1004" y="255"/>
-      <point x="997" y="307" type="curve"/>
-      <point x="1012" y="311"/>
-      <point x="1028" y="315"/>
-      <point x="1044" y="315" type="curve" smooth="yes"/>
-      <point x="1116" y="315"/>
-      <point x="1130" y="216"/>
+      <point x="1166.9" y="200" type="curve" smooth="yes"/>
+      <point x="1166.55" y="142.944"/>
+      <point x="1136.81" y="90.1681"/>
+      <point x="1078.31" y="90.1681" type="curve" smooth="yes"/>
+      <point x="1002.31" y="90.1681"/>
+      <point x="1003.31" y="253.168"/>
+      <point x="996.306" y="305.168" type="curve"/>
+      <point x="1013.31" y="307.901"/>
+      <point x="1050.9" y="314"/>
+      <point x="1066.9" y="314" type="curve" smooth="yes"/>
+      <point x="1139.9" y="314"/>
+      <point x="1167.31" y="267.168"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uniA_B_14.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uniA_B_14.glif
@@ -5,14 +5,14 @@
   <anchor x="599" y="1568" name="U"/>
   <outline>
     <contour>
-      <point x="1356" y="268" type="curve" smooth="yes"/>
-      <point x="1356" y="362"/>
-      <point x="1303" y="434"/>
-      <point x="1205" y="434" type="curve" smooth="yes"/>
-      <point x="1135" y="434"/>
-      <point x="1063" y="417"/>
-      <point x="994" y="408" type="curve"/>
-      <point x="1042" y="809"/>
+      <point x="1356" y="254" type="curve" smooth="yes"/>
+      <point x="1356" y="373"/>
+      <point x="1282" y="410"/>
+      <point x="1174" y="410" type="curve" smooth="yes"/>
+      <point x="1161" y="410"/>
+      <point x="1075" y="389"/>
+      <point x="990" y="385" type="curve"/>
+      <point x="1038" y="786"/>
       <point x="1068" y="1069"/>
       <point x="1068" y="1120" type="curve" smooth="yes"/>
       <point x="1068" y="1177"/>
@@ -68,36 +68,19 @@
       <point x="769" y="809" type="line"/>
       <point x="695" y="174" type="line" smooth="yes"/>
       <point x="692" y="150"/>
-      <point x="691" y="126"/>
-      <point x="691" y="102" type="curve" smooth="yes"/>
-      <point x="691" y="27"/>
+      <point x="691" y="127"/>
+      <point x="691" y="103" type="curve" smooth="yes"/>
+      <point x="691" y="28"/>
       <point x="709" y="0"/>
       <point x="789" y="0" type="curve" smooth="yes"/>
-      <point x="869" y="0"/>
-      <point x="936" y="51"/>
-      <point x="1014" y="51" type="curve" smooth="yes"/>
-      <point x="1055" y="51"/>
-      <point x="1095" y="39"/>
-      <point x="1137" y="39" type="curve" smooth="yes"/>
-      <point x="1249" y="39"/>
-      <point x="1356" y="159"/>
-    </contour>
-    <contour>
-      <point x="1084" y="236" type="curve" smooth="yes"/>
-      <point x="1084" y="189"/>
-      <point x="1072" y="121"/>
-      <point x="1012" y="121" type="curve" smooth="yes"/>
-      <point x="986" y="121"/>
-      <point x="965" y="128"/>
-      <point x="965" y="158" type="curve" smooth="yes"/>
-      <point x="965" y="219"/>
-      <point x="974" y="282"/>
-      <point x="986" y="342" type="curve"/>
-      <point x="995" y="343"/>
-      <point x="1004" y="343"/>
-      <point x="1013" y="343" type="curve" smooth="yes"/>
-      <point x="1087" y="343"/>
-      <point x="1084" y="298"/>
+      <point x="864" y="0"/>
+      <point x="935" y="29"/>
+      <point x="1010" y="29" type="curve" smooth="yes"/>
+      <point x="1058" y="29"/>
+      <point x="1105" y="15"/>
+      <point x="1154" y="15" type="curve" smooth="yes"/>
+      <point x="1276" y="15"/>
+      <point x="1356" y="123"/>
     </contour>
     <contour>
       <point x="1088" y="1400" type="curve"/>
@@ -138,6 +121,23 @@
       <point x="889" y="1339" type="curve" smooth="yes"/>
       <point x="961" y="1339"/>
       <point x="1026" y="1366"/>
+    </contour>
+    <contour>
+      <point x="1152" y="219" type="curve" smooth="yes"/>
+      <point x="1152" y="150.047"/>
+      <point x="1101.13" y="97"/>
+      <point x="1035" y="97" type="curve" smooth="yes"/>
+      <point x="1012" y="97"/>
+      <point x="969" y="104"/>
+      <point x="969" y="135" type="curve" smooth="yes"/>
+      <point x="969" y="174"/>
+      <point x="974" y="251"/>
+      <point x="982" y="307" type="curve"/>
+      <point x="1011" y="318"/>
+      <point x="1037" y="322"/>
+      <point x="1068" y="322" type="curve" smooth="yes"/>
+      <point x="1139" y="322"/>
+      <point x="1152" y="284"/>
     </contour>
   </outline>
 </glyph>

--- a/source/AbyssinicaSIL-Regular.ufo/glyphs/uniA_B_2C_.glif
+++ b/source/AbyssinicaSIL-Regular.ufo/glyphs/uniA_B_2C_.glif
@@ -96,11 +96,11 @@
       <point x="663" y="492" type="curve"/>
       <point x="804" y="481"/>
       <point x="827" y="378"/>
-      <point x="834" y="258" type="curve" smooth="yes"/>
-      <point x="842" y="126"/>
-      <point x="862" y="46"/>
+      <point x="834" y="258" type="curve"/>
+      <point x="845" y="129"/>
+      <point x="860.166" y="50.1603"/>
       <point x="892" y="17" type="curve" smooth="yes"/>
-      <point x="908" y="1"/>
+      <point x="908.167" y="0.159043"/>
       <point x="931" y="-2"/>
       <point x="953" y="-2" type="curve" smooth="yes"/>
       <point x="1029" y="-2"/>
@@ -125,18 +125,18 @@
       <point x="706" y="1075"/>
     </contour>
     <contour>
-      <point x="1258" y="162" type="curve" smooth="yes"/>
-      <point x="1258" y="127"/>
-      <point x="1250" y="92"/>
-      <point x="1207" y="92" type="curve" smooth="yes"/>
-      <point x="1131" y="92"/>
-      <point x="1132" y="255"/>
-      <point x="1125" y="307" type="curve"/>
-      <point x="1140" y="311"/>
-      <point x="1156" y="315"/>
-      <point x="1172" y="315" type="curve" smooth="yes"/>
-      <point x="1244" y="315"/>
-      <point x="1258" y="216"/>
+      <point x="1294.9" y="200" type="curve" smooth="yes"/>
+      <point x="1294.55" y="142.944"/>
+      <point x="1264.81" y="90.1681"/>
+      <point x="1206.31" y="90.1681" type="curve" smooth="yes"/>
+      <point x="1130.31" y="90.1681"/>
+      <point x="1131.31" y="253.168"/>
+      <point x="1124.31" y="305.168" type="curve"/>
+      <point x="1141.31" y="307.901"/>
+      <point x="1178.9" y="314"/>
+      <point x="1194.9" y="314" type="curve" smooth="yes"/>
+      <point x="1267.9" y="314"/>
+      <point x="1295.31" y="267.168"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
# Overview and Redesign Objective
The objective of these submitted glyph enhancements is to improve the readability of the Abyssinica SIL typeface for a number of glyphs in the 5th order (“Hamis”). The affected glyphs are ቤ (U+1264), ቬ (U+126C),  ኜ (U+129C), ዜ (U+12DC), ꬔ (U+AB14), ጼ (U+1334), ጴ (U+133C), and ꬬ (U+AB2C) and their modifications will be reviewed here in turn. These glyphs suffer slightly from having a smaller open area in their diacritic loop (or “ring”) relative to closely related companion glyphs. The smaller area may “close up” at small point sizes making them more difficult to distinguish and the difference from the related glyph can be optically confusing. In some cases, the adjustment to the more Hamis diacritic is intended to help improve consistency in the appearance of these glyphs with respect to the norms seen across the Abyssinica SIL typeface.

A critical consideration in the diacritical mark enhancement was to avoid any impact on the letter widths so as not to impact the textual flow (word and line wraps) of existing documents.  The letter widths, and the left and right side bearings, retain their original values.  Changes to the diacritic mark shapes will borrow from the shapes of similar letters so as to look natural with respect to the typeface.

## ኜ Enhancement
Improvements were made to the ኜ (U+129C) glyph to synchronize it’s Hamis ring with that of ኔ (U+1294), which is also the historic basis for the ኘ letter family. The ኔ is simply substituted for the ኜ ring.  Doing so reduced the right side bearing (RSB) of ኜ from 21 to 7 points.  To return the RSB to 21 points, two outer points of the new ኜ ring are shifted leftward by 14 points.  Thus the ኔ and ኜ rings are not precisely identical, but the difference is minimally perceptible and the ኜ ring is favorably enlarged.

<img width="426" alt="Nyie-enhancement" src="https://github.com/user-attachments/assets/18eb88bc-3c74-403c-b9e1-f9720e35ca26">

## ዜ & ꬔ Enhancement
Similar in process to the ኜ ring enhancement, the ዜ (U+12DC) ring  was replaced with a larger open ring found in the derived letter ዤ (U+12E4). Applying the ዤ diacritic mark to ዜ would then reduce the RSB from 80 to 8 points. Accordingly, the outer two points of the mark are shifted leftward by 72 points. The result is believed to be an overall enhancement. The revised diacritical mark was then simply grafted onto the related letter ꬔ (U+AB14).
<img width="424" alt="Zie-enhancement" src="https://github.com/user-attachments/assets/13abc66e-e0be-476b-b003-818018323337">

## ጼ, ጴ, and ꬬ Enhancement
The inner ring of ጼ is noticeably small relative to the overall size of the diacritic mark and suffers from optical closer at small font point sizes.  A perfect substitute for the inner ring was not found on other letters within the glyph set, so a new inner ring was redesigned based on others that appeared on similarly sized diacritic marks. The inner ring was then simply substituted for the inner rings of ጴ and ꬬ (U+AB2C).

<img width="446" alt="Tsie-Pie-enhancement" src="https://github.com/user-attachments/assets/28d12a15-f5a0-4450-a826-ba97ac050170">

ቤ & ቬ Enhancement
The goal of the ቤ (U+1264) and ቬ (U+126C) enhancements was not to open the diacritic mark’s inner loop more, but rather to adjust the irregular top curve of the mark.  Rather than a smooth concave arch, the marks feature a way stroke that becomes conspicuous and very large point sizes.  A zoomed view of the way stroke is seen below as it appears in a font editor:

<img width="1146" alt="Bie-Hamis-Diacritic" src="https://github.com/user-attachments/assets/8025634f-22c6-46c6-85a8-929b97d74cfc">


The top arc from the ኬ (U+12AC) diacritical mark has been grafted onto the ቤ diacritic. A 2nd adjustment was to the inner ring of the ቤ diacritic mark which was an oval shape. In other cases where the diacritic mark is attached to a vertical, or near vertical, “leg”, the left side of the inner ring will likewise be vertical to preserve the appearance of continuity of the leg stroke. The inner ring was then replaced with the inner ring from ዜ with point adjustments made as necessary.

<img width="480" alt="Bie-Vie-enhancement" src="https://github.com/user-attachments/assets/335e6325-c11b-4a54-805b-0f138dfeda98">


## Miscellaneous Notes
* This pull request includes a simple change to the ግዚ ligature `.glif` file where the glyph note was deleted.  The note itself was just the number "0".  I think this may have been a mangled remnant (due to different UFO tools in use) of the note I added in the previous PR for this ligature.
* Maintaining the glyphs width I believe was a very sensible approach for these modifications.  Maintaining the RSB was probably less essential.  The RSB (and LSB) values in Abyssinica SIL vary a lot, there doesn't appear to be a normal value. If the goal of maintaining the RSB was dropped, the new diacritic marks for ኜ , ዜ, and ꬔ could be set to match their counterpart value (reference glyph) exactly.  Perhaps the LSB could also be adjusted in these cases.  
* This PR is a follow-up to the earlier PR for revision to the ሔ diacritical remark: https://github.com/silnrsi/font-abyssinica/pull/5
* I *think* these glyphs are good and issue-free, I will create some print samples on 10/21 to review and validate.
